### PR TITLE
Fix bundled Linux FFmpeg color conversion for v0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "cerul"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ include = [
     "/README.md", "/README.zh-CN.md", "/README.zh-TW.md", "/DESIGN.md", "/ARCHITECTURE.md", "/CONTRIBUTING.md",
     "/CODE_OF_CONDUCT.md", "/SECURITY.md",
     "/src/**/*.rs", "/examples/*.rs", "/examples/*.md", "/docs/*.md",
-    "/packaging/licenses/*.txt", "/scripts/build-*.sh", "/scripts/package-media-source.sh", "/schemas/*.json", "/prompts/*.md", "/docs/assets/*.png", "/docs/assets/README.md",
+    "/packaging/licenses/*.txt", "/scripts/build-*.sh", "/scripts/test-*.py", "/scripts/package-media-source.sh", "/schemas/*.json", "/prompts/*.md", "/docs/assets/*.png", "/docs/assets/README.md",
     "/models/det.onnx", "/models/rec.onnx", "/models/characters.txt",
     "/models/LICENSE", "/models/README.md",
     "/tests/*.rs", "/tests/*.py",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerul"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 license = "Apache-2.0"
 description = "Searchable video and annotation data, using your own model endpoints"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -29,6 +29,7 @@ protobuf = "*"
 pkgconf = "*"
 
 [dist.dependencies.apt]
+nasm = "*"
 protobuf-compiler = "*"
 libprotobuf-dev = "*"
 pkg-config = "*"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,7 +22,7 @@ cerul search "A person puts a cup on the table" --save ./clips
 On first use, enter your [Gemini API key](https://aistudio.google.com/apikey)
 when prompted. Model processing sends inputs to Gemini and may incur API charges.
 
-You can also download an archive from [GitHub Releases](https://github.com/cerul-ai/cerul/releases/tag/v0.0.3).
+You can also download an archive from [GitHub Releases](https://github.com/cerul-ai/cerul/releases/tag/v0.0.4).
 Keep `cerul`, `cerul-ffmpeg`, and `cerul-ffprobe` together when moving them.
 
 ## Build from source (developers)
@@ -71,7 +71,7 @@ On Ubuntu 24.04:
 
 ```sh
 sudo apt-get update
-sudo apt-get install -y git build-essential pkg-config libssl-dev protobuf-compiler libprotobuf-dev curl xz-utils bzip2
+sudo apt-get install -y git build-essential nasm pkg-config libssl-dev protobuf-compiler libprotobuf-dev curl xz-utils bzip2
 ```
 
 Install a stable Rust toolchain using the instructions at [rustup.rs](https://rustup.rs)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,6 +1,6 @@
 # Release artifacts
 
-The v0.0.3 rewrite is not published by building or reviewing this branch.
+The v0.0.4 rewrite is not published by building or reviewing this branch.
 Package publishing is a separate release operation after M1 acceptance.
 Existing tags and `ffmpeg-vendor-*` assets must be preserved for downstream compatibility.
 
@@ -11,19 +11,19 @@ npm and Homebrew publishing can follow separately.
 
 1. Verify PR checks and acceptance results, then merge the release PR into `main`.
 2. From the merged `main`, confirm Cargo.toml and packaging/dist.toml both use
-   `0.0.3`, then create and push the version tag:
+   `0.0.4`, then create and push the version tag:
 
    ```sh
    git switch main
    git pull --ff-only origin main
-   git tag -a v0.0.3 -m "Release Cerul 0.0.3"
-   git push origin v0.0.3
+   git tag -a v0.0.4 -m "Release Cerul 0.0.4"
+   git push origin v0.0.4
    ```
 
 3. Wait for the Release workflow to publish both platform archives, the shell
    installer, checksums, and corresponding media sources to GitHub Releases.
 4. Configure `https://cerul.ai/install.sh` to redirect temporarily (HTTP 302 or 307)
-   to `https://github.com/cerul-ai/cerul/releases/download/v0.0.3/cerul-installer.sh`.
+   to `https://github.com/cerul-ai/cerul/releases/download/v0.0.4/cerul-installer.sh`.
    Use short caching so the target can be updated for future releases. Verify
    that following the redirect returns the shell script, not an HTML page.
 5. On each supported platform, install from the public README command and verify
@@ -75,7 +75,7 @@ written under `target/distrib/`, including:
 - `cerul-<target>.tar.xz` and SHA-256 files.
 - `cerul-installer.sh`.
 - `cerul.rb`, a Homebrew formula.
-- `cerul-npm-package.tar.gz`, the `cerul` 0.0.3 npm wrapper.
+- `cerul-npm-package.tar.gz`, the `cerul` 0.0.4 npm wrapper.
 - A source archive and aggregate checksums.
 
 The source archive uses committed Git content. Regenerate it after committing;

--- a/packaging/dist.toml
+++ b/packaging/dist.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerul"
-version = "0.0.3"
+version = "0.0.4"
 description = "Searchable video and annotation data, using your own model endpoints"
 license = "Apache-2.0 AND GPL-2.0-or-later AND Zlib"
 homepage = "https://cerul.ai"

--- a/scripts/build-distribution.sh
+++ b/scripts/build-distribution.sh
@@ -6,6 +6,9 @@ host=$(rustc -vV | sed -n 's/^host: //p')
 target=${CARGO_DIST_TARGET:-$host}
 if [[ "$target" != "$host" ]]; then echo 'Distribution builds must run on the target platform.' >&2; exit 1; fi
 bash scripts/build-media.sh
+if [[ "${CI:-}" == true ]]; then
+  python3 scripts/test-media.py target/bundle
+fi
 cargo build --release --locked --bin cerul
 cp target/release/cerul target/bundle/cerul
 if [[ "${CI:-}" == true ]]; then

--- a/scripts/build-media.sh
+++ b/scripts/build-media.sh
@@ -51,7 +51,7 @@ make install
 cd ../ffmpeg-7.1.4
 PKG_CONFIG_PATH="$prefix/lib/pkgconfig" ./configure --prefix="$prefix" \
   --disable-autodetect --disable-shared --enable-static --enable-gpl --enable-libx264 --enable-zlib \
-  --disable-doc --disable-debug --disable-ffplay --disable-network --disable-x86asm \
+  --disable-doc --disable-debug --disable-ffplay --disable-network \
   --disable-videotoolbox --disable-audiotoolbox --disable-securetransport \
   --extra-cflags="-I$prefix/include" --extra-ldflags="-L$prefix/lib" --pkg-config-flags=--static
 make -j"$jobs" ffmpeg ffprobe

--- a/scripts/test-bundle.py
+++ b/scripts/test-bundle.py
@@ -22,11 +22,12 @@ with tempfile.TemporaryDirectory(prefix="cerul-bundle-test-") as temp:
     subprocess.run([str(bundle / "cerul-ffmpeg"), "-v", "error", "-loop", "1", "-i", str(root / "tests/fixtures/ocr-text.png"), "-t", "1", "-r", "2", "-pix_fmt", "yuv420p", "-c:v", "libx264", str(temp / "demo.mp4")], env=env, check=True)
     result = subprocess.run([str(bundle / "cerul"), "--json", "--workspace", str(temp / "workspace"), "index", str(temp / "demo.mp4"), "--no-audio", "--jobs", "1"], env=env, capture_output=True, text=True, timeout=120)
     assert result.returncode == 6, (result.returncode, result.stdout, result.stderr)
-    json.loads(result.stdout)
+    indexed = json.loads(result.stdout)
+    assert all(len(stream["errors"]) == 1 and "GEMINI_API_KEY" in stream["errors"][0] for episode in indexed["episodes"] for stream in episode["streams"]), indexed
     result = subprocess.run([str(bundle / "cerul"), "--json", "--workspace", str(temp / "workspace"), "search", "--text", "CERUL"], env=env, capture_output=True, text=True, timeout=30)
     assert result.returncode == 0, (result.stdout, result.stderr)
     data = json.loads(result.stdout)
-    assert data["hits"], data
+    assert data["hits"], {"search": data, "index": indexed, "ocr": [p.read_text() for p in temp.rglob("screen_text.jsonl")]}
     assert "CERUL" in json.dumps(data["hits"]).upper(), data
     assert not (home / ".cerul/credentials.json").exists()
 print("Bundle passed: no PATH tools, real H.264 encode/probe, OCR, text search, noninteractive missing-key handling.")

--- a/scripts/test-media.py
+++ b/scripts/test-media.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Catch color conversion corruption before compiling the CLI release binary."""
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+bundle = Path(sys.argv[1]).resolve()
+fixture = Path(__file__).resolve().parent.parent / "tests/fixtures/ocr-text.png"
+ffmpeg = str(bundle / "cerul-ffmpeg")
+with tempfile.TemporaryDirectory(prefix="cerul-media-test-") as directory:
+    video = Path(directory) / "gray.mp4"
+    subprocess.run([ffmpeg, "-v", "error", "-loop", "1", "-i", str(fixture),
+                    "-t", "1", "-r", "2", "-pix_fmt", "yuv420p", "-c:v", "libx264", str(video)], check=True)
+    pixels = subprocess.check_output([ffmpeg, "-v", "error", "-i", str(video),
+                                      "-frames:v", "1", "-f", "rawvideo", "-pix_fmt", "rgb24", "-"])
+    assert pixels and len(pixels) % 3 == 0, "missing RGB frame"
+    difference = sum(abs(r - g) + abs(g - b) for r, g, b in zip(pixels[0::3], pixels[1::3], pixels[2::3])) / (len(pixels) / 3)
+    assert difference < 4, f"grayscale frame has color corruption: mean channel difference {difference:.2f}"
+print("Media passed: H.264 RGB/YUV conversion preserves grayscale without color stripes.")


### PR DESCRIPTION
The v0.0.3 release smoke test caught green/magenta stripes in grayscale video on Linux. The failure reproduces with the packaged binaries and disappears with CPU optimizations disabled. Remove the incomplete --disable-x86asm configuration and provide NASM at build time. Add an RGB/YUV grayscale regression check before the expensive Rust build, retain the no-key OCR/search check with better diagnostics, and prepare v0.0.4 without moving the existing tag. Validation: 92 local Rust tests, Clippy, fmt, shell/Python syntax, dist generation, and macOS media regression passed. Corrected Linux media build validation passed in an isolated Linux x86_64 container: grayscale color conversion, bundled H.264 encoding/decoding, real OCR, and text search without PATH tools or model credentials. The same CLI binary reproduces the failure with the old media tools and passes with the corrected tools. Native CI is running.
