### PR TITLE
Give the CLI a presentation layer for people

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,9 +740,12 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "clap_complete",
+ "console",
  "futures",
  "image",
  "imageproc",
+ "indicatif",
  "lancedb",
  "parquet",
  "reqwest",
@@ -828,6 +831,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +897,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1934,6 +1959,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,6 +2766,19 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
 ]
 
 [[package]]
@@ -4186,6 +4230,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object_store"
@@ -6751,6 +6801,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ include = [
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
+clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = "1"
@@ -46,6 +47,8 @@ imageproc = { version = "0.25", default-features = false }
 
 tempfile = "3"
 rpassword = "7"
+indicatif = "0.17"
+console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
 
 [profile.dev]
 debug = 0

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -9,7 +9,7 @@ Public design reference for the local video processing core.
 | Area | Decision |
 | --- | --- |
 | Language | Rust, one crate with a library and one binary. ffmpeg subprocesses, four endpoint types, LanceDB, and embedded OCR. No PyTorch, GPU runtime, Python runtime, or plugins. |
-| Commands | M1: `index`, `annotate`, `search`, `status`, `clean`. HTTP and MCP `serve` belong to M2. |
+| Commands | M1: `index`, `search`, `status`, `open`, `auth`, `annotate`, `remove`. HTTP and MCP `serve` belong to M2. |
 | Structure | Logic lives in library modules exposed through `lib.rs`. `main.rs` parses arguments, calls the library, and prints results. Desktop can link the library or consume subprocess JSON events without `serve`. |
 | Source of truth | One sidecar directory per episode, using JSONL and Parquet, **including embedding vectors**. Indexes are caches rebuildable from sidecars without model calls. |
 | Indexes | One LanceDB directory per `space_id`, the hash of provider kind, base URL, model, dimensions, and query instruction template. The same model name at different endpoints is a different space. Queries must match exactly. |
@@ -26,7 +26,7 @@ Public design reference for the local video processing core.
 | Versions | Increment `v0.0.x` without alpha/beta suffixes. The old npm package reached 0.0.2; the first rewritten release is **v0.0.3**, with the same version on crates.io. Milestones M1/M2/M3 are not fixed version numbers. |
 | Distribution | cargo-dist shell installer, Homebrew formula, and npm `cerul` wrapper. |
 | Telemetry | None. |
-| Scope | M1 is a complete video retrieval and semantic annotation CLI requiring only third-party model credentials. Pose, depth, and segmentation depend on later perception services and must not be advertised as available. |
+| Scope | M1 is a complete video retrieval and semantic annotation CLI requiring only third-party model credentials. `status --providers` probes only the endpoints M1 uses; the later-milestone perception endpoint is contacted solely when configured explicitly. Pose, depth, and segmentation depend on later perception services and must not be advertised as available. |
 
 ## 2. Usage
 
@@ -50,6 +50,8 @@ Complete distributions install `cerul-ffmpeg` and `cerul-ffprobe` beside the CLI
 ## 3. Commands
 
 Global options: `--json`, `--workspace`, `--recompute`, `--dry-run`, `--yes`, `-q`, `-v`. Configuration overrides use repeated `--set KEY=TOML_VALUE`.
+
+Without `--json` the CLI renders text for people: a start page for a bare `cerul` that walks through setup until the first video is searchable, live progress on a terminal (one line per finished station when redirected), one card per matched video listing its moments, and errors with a recovery hint on stderr. Cards carry the file name, match percentage, time range, excerpt, and an OSC 8 link; terminals with the iTerm2 or Kitty graphics protocol also show a still frame. When a player that accepts a start time is installed the link opens the moment rather than the file. Model requests whose duration cannot be predicted show a spinner. `index` prints the stations it will run before the first request, and collapses each finished video into one line so the live area stays the size of the video being worked on. Colour, links, and images follow the terminal and `NO_COLOR`, so redirected output stays plain. `cerul auth [set|remove]` manages the saved Gemini key. Rendering lives in the binary only; the library never touches a terminal.
 
 In JSON mode, stdout contains exactly one final JSON object. Each stderr line is a JSON event, for example:
 
@@ -75,6 +77,32 @@ Accept files, directories, and automatically detected LeRobot v3 datasets.
 
 Pipeline: discover → SHA-256 → ffprobe → transcript/screen_text/embed stations → Lance publication. Skip completed outputs when content, model, and parameters match.
 
+### `remove [path...] [--cache] [--all-indexes] [--index SPACE_ID] [--compact]`
+
+One command gets rid of things, because from a person's side forgetting a video
+and reclaiming disk are the same verb. Named paths delete those episodes'
+sidecars and the projections built from them, leaving the media untouched;
+interactive runs confirm first, `--yes` skips the question, and non-terminal
+callers must pass it. A path that was never indexed is reported, not an error.
+The flags free only regenerable artifacts and never ask, because nothing is
+lost: caches are recreated on demand and search indexes rebuild from sidecars
+with no model calls, which is what acceptance criterion 7 exercises. Status
+lists space IDs. Everything supports `--dry-run`. Sidecar deletion records
+durable intent before removing index rows and files; if interrupted, repeating
+the command resumes even when the sidecar is partially removed or absent. Dry
+runs never record intent or delete data.
+
+### `completions <shell>`
+
+Prints a completion script for bash, zsh, fish, elvish, or powershell to stdout.
+
+### `open [N]`
+
+Plays result `N` (default 1) from the last search, starting at its moment. The
+last search is remembered in workspace `cache/last-search.json`. Players are
+tried in order: mpv, IINA, VLC, ffplay, then the system handler, which cannot
+start at a timestamp and says so.
+
 ### `annotate <path>... --semantic [items] --grounding [items] --world [items]`
 
 | Options | Behavior/default |
@@ -97,6 +125,9 @@ Each subtype is a module: frames → timestamped contact sheet → schema-constr
 | `--in PATH` | Restrict the searched input scope. |
 | `--count` | Filters only: return exact-label record and episode counts. No natural-language probe counting. |
 | `--save DIR`, `--pad 2s` | Save matched MP4 clips. |
+| `--preview`, `--no-preview` | Cache one still frame per hit under workspace `cache/previews/` and expose it as `preview`. Stills use input seeking, so their cost does not grow with recording length. Default: on when the terminal can draw images. |
+
+Query embeddings are cached under workspace `cache/queries/` keyed by embedding space and query, so repeating or refining a search needs no further model call. Both caches are disposable and freed by `remove --cache`.
 | `--rerank` | M2: vision reranking of the first 20 candidates. |
 | `--text` | Substring match over transcript and screen text without vectors. |
 
@@ -107,10 +138,6 @@ Results: `hits[]` containing episode, stream, start_us, end_us, optional frame_r
 Return a workspace overview or an episode's annotation inventory. Running `cerul` without a command is equivalent to status.
 
 Ordinary status does not probe remote endpoints; remote capabilities are null (unknown). `--providers` probes all four endpoints, caching successful checks for seven days. `--recompute` refreshes checks; `--dry-run` performs none. Explicit probes report endpoint, model, check time, and error. Unsupported is false; missing keys and network errors remain null. Preserve other endpoint results when one fails and return exit code 6. The JSON root contains `capabilities`. Perception's advertised tasks do not imply that M1 implements grounding/world.
-
-### `clean`
-
-Options: `--index SPACE_ID`, `--all-indexes`, `--cache`, `--compact`. Status lists space IDs and corresponding models. Only `--sidecars PATH --yes` deletes sidecars. All cleanup operations support `--dry-run`. Explicit sidecar deletion records durable intent before removing index rows and files. If interrupted, repeating the same explicit cleanup resumes even when the sidecar is partially removed or absent. Dry runs never record intent or delete data.
 
 ## 4. Configuration and models
 
@@ -266,7 +293,7 @@ Prefer --out. Stage a complete dataset, perform native field/timeline validation
 
 ### Search
 
-Parse filters into episode/stream half-open time intervals, then apply them as Lance prefilters to intersecting chunks before vector ranking. Group the same interval by highest score and retain matched provenance; merge adjacent results. Reranking is M2.
+Parse filters into episode/stream half-open time intervals, then apply them as Lance prefilters to intersecting chunks before vector ranking. Group the same interval by highest score and retain matched provenance. Exact-text hits merge when adjacent; ranked vector hits merge only when their windows mostly coincide, so the small overlap between neighbouring index windows never chains a whole video into one hit. Reranking is M2.
 
 Repeated filters are AND. Conditions on one annotation must match the same record. Different annotations join by temporal intersection. Episode/stream/kind constrain scope. A chunk is eligible when its interval intersects the event interval; the hit time is that intersection.
 
@@ -294,7 +321,7 @@ Every PR runs offline tests and two-platform builds. Protected-branch validation
 
 | Milestone | Scope |
 | --- | --- |
-| **M1**, first release v0.0.3 | Index (transcript, OCR, embedding, still detection); search (vectors, images, prefilters, filter counts, saving clips, exact text); status; clean; semantic annotation; LeRobot reading and subtask writeback; macOS/Linux distribution; replace the old npm cerul wrapper. |
+| **M1**, first release v0.0.3 | Index (transcript, OCR, embedding, still detection); search (vectors, images, prefilters, filter counts, saving clips, exact text); status; removal and disk reclamation; semantic annotation; LeRobot reading and subtask writeback; macOS/Linux distribution; replace the old npm cerul wrapper. |
 
 Acceptance requirements:
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ curl -fsSL https://cerul.ai/install.sh | sh
 cerul index ./demo.mp4
 ```
 
-On first use, follow the prompt to enter your [Gemini API key](https://aistudio.google.com/apikey).
-Cerul saves it on your computer for future runs. Model processing sends data to
-Gemini and may incur API charges.
+On first use, follow the prompt to enter your [Gemini API key](https://aistudio.google.com/apikey),
+or save one ahead of time with `cerul auth set`. Cerul keeps it on your computer
+for future runs. Model processing sends data to Gemini and may incur API charges.
+
+Run `cerul` on its own at any time to see what is indexed and what to do next.
 
 ### 3. Search and save clips
 
@@ -64,6 +66,27 @@ Gemini and may incur API charges.
 cerul search "A person puts a cup on the table"
 cerul search "A person puts a cup on the table" --save ./clips
 ```
+
+Each result is a card with the match percentage, the time range, and a link. In
+iTerm2, Ghostty, Kitty, or WezTerm it also shows a still frame of the moment; add
+`--no-preview` to turn that off. With [IINA](https://iina.io) installed the link
+opens the video at the matched moment instead of the beginning.
+
+Results are numbered, so `cerul open 2` plays the second moment in your video
+player without leaving the terminal.
+
+### Housekeeping
+
+```sh
+cerul remove ./demo.mp4      # forget one video; the file itself stays
+cerul remove --cache         # free regenerable disk space
+cerul completions zsh        # shell completion script
+```
+
+For zsh, save it somewhere on your `fpath`, for example
+`cerul completions zsh > ~/.zfunc/_cerul`, then make sure `~/.zfunc` is in
+`fpath` before `compinit` runs. For bash,
+`cerul completions bash > /usr/local/etc/bash_completion.d/cerul`.
 
 [More examples →](examples/video-search.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,7 +50,9 @@ curl -fsSL https://cerul.ai/install.sh | sh
 cerul index ./demo.mp4
 ```
 
-第一次使用时，按提示输入 [Gemini API key](https://aistudio.google.com/apikey)，之后无需重复输入。模型处理会将数据发送给 Gemini，并可能产生 API 费用。
+第一次使用时，按提示输入 [Gemini API key](https://aistudio.google.com/apikey)，也可以提前用 `cerul auth set` 保存，之后无需重复输入。模型处理会将数据发送给 Gemini，并可能产生 API 费用。
+
+随时直接运行 `cerul`，可以看到已索引的视频和下一步命令。
 
 ### 3. 搜索并保存片段
 
@@ -58,6 +60,20 @@ cerul index ./demo.mp4
 cerul search "有人把杯子放到桌上"
 cerul search "有人把杯子放到桌上" --save ./clips
 ```
+
+每条结果是一张卡片，显示匹配度、时间区间和链接。在 iTerm2、Ghostty、Kitty 或 WezTerm 中还会显示该瞬间的画面截图，用 `--no-preview` 可以关闭。装了 [IINA](https://iina.io) 时，链接会直接跳到匹配的时间点，而不是从头播放。
+
+结果都有编号，`cerul open 2` 会用播放器直接从第二个片段开始播，不用离开终端。
+
+### 日常维护
+
+```sh
+cerul remove ./demo.mp4      # 忘掉某个视频的索引，视频文件本身保留
+cerul remove --cache         # 释放可再生的磁盘占用
+cerul completions zsh        # 生成 shell 补全脚本
+```
+
+zsh 用户把它放到 `fpath` 里，例如 `cerul completions zsh > ~/.zfunc/_cerul`，并确保 `~/.zfunc` 在 `compinit` 之前加入 `fpath`。
 
 [更多使用示例 →](examples/video-search.md)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -50,7 +50,9 @@ curl -fsSL https://cerul.ai/install.sh | sh
 cerul index ./demo.mp4
 ```
 
-第一次使用時，依提示輸入 [Gemini API key](https://aistudio.google.com/apikey)，之後無需重複輸入。模型處理會將資料傳送給 Gemini，並可能產生 API 費用。
+第一次使用時，依提示輸入 [Gemini API key](https://aistudio.google.com/apikey)，也可以先用 `cerul auth set` 儲存，之後無需重複輸入。模型處理會將資料傳送給 Gemini，並可能產生 API 費用。
+
+隨時直接執行 `cerul`，即可看到已索引的影片和下一步指令。
 
 ### 3. 搜尋並儲存片段
 
@@ -58,6 +60,20 @@ cerul index ./demo.mp4
 cerul search "有人把杯子放到桌上"
 cerul search "有人把杯子放到桌上" --save ./clips
 ```
+
+每筆結果是一張卡片，顯示匹配度、時間區間和連結。在 iTerm2、Ghostty、Kitty 或 WezTerm 中還會顯示該瞬間的畫面截圖，用 `--no-preview` 可以關閉。裝了 [IINA](https://iina.io) 時，連結會直接跳到匹配的時間點，而不是從頭播放。
+
+結果都有編號，`cerul open 2` 會用播放器直接從第二個片段開始播，不用離開終端。
+
+### 日常維護
+
+```sh
+cerul remove ./demo.mp4      # 忘掉某個影片的索引，影片檔案本身保留
+cerul remove --cache         # 釋放可再生的磁碟佔用
+cerul completions zsh        # 產生 shell 補全指令碼
+```
+
+zsh 使用者把它放到 `fpath` 裡，例如 `cerul completions zsh > ~/.zfunc/_cerul`，並確保 `~/.zfunc` 在 `compinit` 之前加入 `fpath`。
 
 [更多使用範例 →](examples/video-search.md)
 

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -42,10 +42,11 @@ and `cerul --json status`. Report the executable path and version. Do not use
 ### 4. Configure credentials and choose a video
 
 Reuse an explicitly configured model endpoint and credentials. Otherwise guide
-the user to run their first `cerul index` in their own interactive terminal for
-hidden key entry, or set `GEMINI_API_KEY` locally through their secret manager.
+the user to run `cerul auth set` in their own interactive terminal for hidden
+key entry, or set `GEMINI_API_KEY` locally through their secret manager.
 Saved keys are reused by noninteractive calls. JSON/agent calls never prompt.
-Check presence only; never echo a key, dump the environment, include credentials
+Check presence only with `cerul --json auth` (it reports whether a key is saved
+or exported, never the value); never echo a key, dump the environment, include credentials
 in logs, or copy them to the repository. Do not source an unrelated project's
 entire `.env` file. If the user supplies a credential file, parse only the named
 value as data and scope it to the child process that needs it.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,8 +22,10 @@ Store only the key's environment variable name in configuration, never the key.
 
 The CLI can save a validated default Gemini key in `~/.cerul/credentials.json`
 (mode 0600). Stored keys are scoped to endpoint kind, service URL, and key
-variable name. Environment values override saved keys. The first interactive
-processing command offers hidden setup when needed; JSON, quiet, yes, dry-run,
+variable name. Environment values override saved keys. `cerul auth` shows where
+the key would come from, `cerul auth set` enters and verifies one, and
+`cerul auth remove` deletes the saved copy. The first interactive processing
+command offers the same hidden setup when needed; JSON, quiet, yes, dry-run,
 and non-terminal calls never prompt. See [installation](installation.md) for
 storage, removal, and agent setup. Library callers do not read this file.
 
@@ -65,9 +67,13 @@ Ordinary `status`, exact text search, annotation-only filters, index rebuilds,
 and cleanup do not probe providers. Commands probe only endpoints needed for
 pending work. Successful probes are cached for seven days.
 
-`cerul status --providers` explicitly probes all four configured endpoints,
-including the future perception endpoint. It may return a partial result when
-one endpoint is unavailable even if the endpoints needed for M1 are usable.
+`cerul status --providers` explicitly probes the endpoints M1 uses: embedding,
+vision, and transcription. The perception endpoint belongs to a later milestone
+and its default address is not a running service, so it is probed only after you
+point it somewhere yourself or set its key variable; until then its capability
+stays null and no request leaves your machine for it. The command may return a
+partial result when one endpoint is unavailable even if the endpoints needed for
+M1 are usable.
 Use `--recompute` to refresh successful probes and `--dry-run` to avoid probes.
 Capability values are true for supported, false for explicitly unsupported,
 and null for unknown (including missing credentials and network errors).

--- a/examples/generate_schemas.rs
+++ b/examples/generate_schemas.rs
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
             schema::<cerul::annotate::schema::Window<cerul::annotate::schema::Progress>>(),
         ),
         ("search-result", schema::<cerul::search::Report>()),
-        ("clean-result", schema::<cerul::clean::Report>()),
+        ("remove-result", schema::<cerul::clean::Report>()),
         ("indexed-record", schema::<cerul::index::records::Row>()),
         ("index-result", schema::<cerul::index::pipeline::Report>()),
         ("annotation", schema::<cerul::annotations::AnnotationFile>()),

--- a/examples/video-search.md
+++ b/examples/video-search.md
@@ -39,6 +39,18 @@ call a model. Hits contain episode-relative integer microseconds and identify
 whether video, speech, or screen text matched. `--save` extracts clips with two
 seconds of padding, clamped to the episode's source range.
 
+In a terminal the hits are grouped into one card per video, each moment carrying
+its match percentage, time range, excerpt, and a link. With IINA installed the
+link opens the video at the matched moment; otherwise it opens the file from the
+beginning. Every moment is numbered, and `cerul open N` plays that moment with
+mpv, IINA, VLC, or ffplay when one of them is installed. Terminals implementing the iTerm2 or Kitty graphics
+protocol (iTerm2, Ghostty, Kitty, WezTerm) also draw a still frame from the start
+of the hit; `--preview` forces the frames and `--no-preview` suppresses them.
+Frames are cached under workspace `cache/previews/`, query embeddings under
+`cache/queries/`, and both are freed by `cerul remove --cache`. The first search
+of a new phrase waits for one model request; repeating or refining it is local. Visual hits cover a whole index window, so re-index with a
+shorter `--chunk` when you need finer moments.
+
 ## Add semantic annotations
 
 ```sh
@@ -61,10 +73,15 @@ Ctrl-C cancels processing; rerun the command to complete missing units. A partia
 result uses exit code 6 and reports the incomplete stations.
 
 ```sh
-cerul clean --all-indexes --dry-run
-cerul clean --all-indexes
+cerul remove --all-indexes --dry-run
+cerul remove --all-indexes
 cerul index ./demo.mp4
 ```
+
+The same command forgets one video: `cerul remove ./demo.mp4` deletes that
+video's sidecar and the rows projected from it. The video file is never touched,
+a path that was never indexed is reported rather than treated as an error, and
+an interactive run confirms before anything authoritative is lost.
 
 The final command restores indexes from intact sidecar vectors without model
 calls. Cache/index cleaning preserves sidecars and source media. Deleting

--- a/schemas/remove-result.json
+++ b/schemas/remove-result.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://cerul.ai/schemas/clean-result/1",
+  "$id": "https://cerul.ai/schemas/remove-result/1",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Report",
   "type": "object",

--- a/schemas/search-result.json
+++ b/schemas/search-result.json
@@ -96,6 +96,22 @@
             }
           ]
         },
+        "media": {
+          "description": "Source media file for the hit's stream, when it is a video stream.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "preview": {
+          "description": "Still frame from the start of the hit, for hosts that show thumbnails.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
         "score": {
           "type": [
             "number",

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -82,6 +82,50 @@ pub fn resolver(
     })
 }
 
+/// Where the key for an endpoint would come from, for display.
+pub fn state(endpoint: &Endpoint) -> crate::render::KeyState {
+    let saved = path()
+        .as_deref()
+        .map(read)
+        .and_then(Result::ok)
+        .is_some_and(|keys| keys.contains_key(&credential_scope(endpoint)));
+    crate::render::KeyState {
+        provider: endpoint.kind.clone(),
+        endpoint: endpoint.base_url.clone(),
+        env: endpoint.api_key_env.clone(),
+        env_set: std::env::var(&endpoint.api_key_env).is_ok_and(|v| !v.trim().is_empty()),
+        saved,
+        credentials_path: path(),
+    }
+}
+
+/// Interactive replacement of the saved key, used by `cerul auth set`.
+pub async fn set(endpoint: &Endpoint, cancel: CancellationToken) -> Result<()> {
+    ensure!(
+        std::io::stdin().is_terminal() && std::io::stderr().is_terminal(),
+        "cerul auth set needs an interactive terminal; export {} instead",
+        endpoint.api_key_env
+    );
+    let mut keys = path().as_deref().map(read).transpose()?.unwrap_or_default();
+    prompt(endpoint, &mut keys, cancel)
+        .await?
+        .context("this endpoint does not support saved keys; export the configured environment variable instead")?;
+    Ok(())
+}
+
+/// Deletes the saved key for an endpoint. Returns whether one existed.
+pub fn remove(endpoint: &Endpoint) -> Result<bool> {
+    let Some(path) = path() else {
+        return Ok(false);
+    };
+    let mut keys = read(&path)?;
+    let existed = keys.remove(&credential_scope(endpoint)).is_some();
+    if existed {
+        save(&path, &keys)?;
+    }
+    Ok(existed)
+}
+
 async fn prompt(
     endpoint: &Endpoint,
     keys: &mut Keys,
@@ -95,13 +139,18 @@ async fn prompt(
     }
     let scope = credential_scope(endpoint);
     let path = path();
+    let palette = crate::render::Palette::new(console::colors_enabled_stderr());
+    eprintln!();
     eprintln!(
-        "First run: Cerul needs a Gemini API key. Get one at https://aistudio.google.com/apikey"
+        "{}",
+        palette.bold("Cerul needs a Gemini API key for speech and semantic search.")
     );
+    eprintln!("  Get one at https://aistudio.google.com/apikey");
     eprintln!(
-        "The key is stored privately in ~/.cerul/credentials.json. Configured models receive media during processing and may charge usage. A small text request validates this key now."
+        "  {}",
+        palette.dim("Stored privately in ~/.cerul/credentials.json. Gemini receives media during processing; API charges may apply.")
     );
-    let key = rpassword::prompt_password("Gemini API key (hidden; leave blank to cancel): ")
+    let key = rpassword::prompt_password("Gemini API key (hidden, blank to cancel): ")
         .inspect_err(|error| {
             if error.kind() == std::io::ErrorKind::Interrupted {
                 cancel.cancel();
@@ -111,19 +160,25 @@ async fn prompt(
         cancel.cancel();
         anyhow::bail!("setup cancelled");
     }
+    eprint!(
+        "{}",
+        palette.dim("  checking the key with a small text request…")
+    );
     let validation = cerul::config::Config::default().embedding;
     let provider = Provider::new(validation, Some(key.trim().to_owned()), 1, None, cancel)?;
-    provider
+    let checked = provider
         .embed(Input::Text("Cerul setup".into()), true)
-        .await
-        .context("API key validation failed; key was not saved")?;
+        .await;
+    eprintln!();
+    checked.context("API key validation failed; key was not saved")?;
     keys.insert(scope, key.trim().to_owned());
     save(
         path.as_deref()
             .context("HOME is required to save credentials")?,
         keys,
     )?;
-    eprintln!("API key verified and saved. Continuing…");
+    eprintln!("{} Key verified and saved", palette.ok("✓"));
+    eprintln!();
     Ok(Some(key.trim().to_owned()))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,153 +1,262 @@
 mod credentials;
+mod render;
 use anyhow::{Context, Result};
 use cerul::{
     config::Config,
     events::Event,
-    index::{embed, pipeline},
+    index::{discover, embed, pipeline},
     providers::{Failure, ProviderError},
 };
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
+use render::{Mode, Palette};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fs,
     io::{self, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
+    process::Stdio,
     sync::{Arc, Mutex},
 };
 use tokio_util::sync::CancellationToken;
+
+const ADVANCED: &str = "Advanced";
+const GLOBAL: &str = "Global";
+const EXAMPLES: &str = "\
+Examples:
+  cerul index ./demo.mp4                 index a video (screen text, speech, search)
+  cerul search \"a person holding a cup\"  find moments by description
+  cerul search --text \"ERROR 500\"        exact words on screen or in speech
+  cerul search \"...\" --save ./clips      export matching clips as MP4
+  cerul open 2                           play the second result at its moment
+  cerul status                           what is indexed and which models are used
+
+Speech and semantic search use Gemini; run `cerul auth set` once to save a key.
+Add --json to any command for machine-readable output.
+Shell completion: cerul completions <shell>.";
 
 #[derive(Parser)]
 #[command(
     name = "cerul",
     version,
-    about = "Searchable video and annotation data"
+    about = "Search your videos with words",
+    long_about = "Search your videos with words.\n\nCerul indexes screen text, speech, and visual content locally, then finds moments from a description and exports them as clips.",
+    after_help = EXAMPLES,
+    disable_help_subcommand = true
 )]
 struct Cli {
-    #[arg(long, global = true)]
+    /// Machine-readable output: final JSON on stdout, NDJSON events on stderr.
+    #[arg(long, global = true, help_heading = GLOBAL)]
     json: bool,
-    #[arg(long, env = "CERUL_WORKSPACE", global = true)]
+    /// Where indexes and caches live (default ~/.cerul).
+    #[arg(long, env = "CERUL_WORKSPACE", global = true, value_name = "DIR", help_heading = GLOBAL)]
     workspace: Option<PathBuf>,
-    #[arg(long, global = true)]
-    recompute: bool,
-    #[arg(long, global = true)]
+    /// Show what would happen without writing anything or calling models.
+    #[arg(long, global = true, help_heading = GLOBAL)]
     dry_run: bool,
-    #[arg(long, global = true)]
+    /// Skip confirmations and never prompt; fail instead of asking for a key.
+    #[arg(short = 'y', long, global = true, help_heading = GLOBAL)]
     yes: bool,
-    /// Override a configuration field, for example embedding.dims=1536.
-    #[arg(long = "set", global = true, value_name = "KEY=TOML_VALUE")]
-    overrides: Vec<String>,
-    #[arg(short = 'q', long, global = true)]
+    /// Only print errors.
+    #[arg(short = 'q', long, global = true, help_heading = GLOBAL)]
     quiet: bool,
-    #[arg(short='v', action=clap::ArgAction::Count, global=true)]
+    /// Redo work even when a valid result already exists.
+    #[arg(long, global = true, help_heading = ADVANCED)]
+    recompute: bool,
+    /// Override a configuration field, for example embedding.dims=1536.
+    #[arg(
+        long = "set",
+        global = true,
+        value_name = "KEY=TOML_VALUE",
+        help_heading = ADVANCED
+    )]
+    overrides: Vec<String>,
+    /// More diagnostic output (repeatable).
+    #[arg(short='v', action=clap::ArgAction::Count, global=true, help_heading = ADVANCED)]
     verbose: u8,
     #[command(subcommand)]
     command: Option<Command>,
 }
 #[derive(Subcommand)]
 enum Command {
-    /// Show local episode, annotation, and vector space inventory.
+    /// Index videos so they can be searched (screen text, speech, visual search).
+    Index(IndexArgs),
+    /// Find moments by description, exact words, or a reference image.
+    Search(SearchArgs),
+    /// Show indexed videos, model configuration, and storage.
     Status {
+        /// Only report videos under this path.
         path: Option<PathBuf>,
-        /// Probe configured endpoints, reusing successful checks for seven days.
+        /// Verify configured model endpoints with small test requests (cached for seven days).
         #[arg(long)]
         providers: bool,
     },
-    /// Index videos using OCR, transcription, and multimodal embeddings.
-    Index(IndexArgs),
-    /// Remove disposable indexes/cache, or explicitly selected sidecars.
-    Clean(CleanArgs),
-    /// Search video, speech, screen text, or annotation intervals.
-    Search(SearchArgs),
-    /// Generate semantic video annotations.
+    /// Open a result from the last search in a video player, at its moment.
+    Open {
+        /// Result number shown by the last search.
+        #[arg(default_value_t = 1, value_name = "N")]
+        number: usize,
+    },
+    /// Manage the saved Gemini API key.
+    Auth(AuthArgs),
+    /// Generate semantic annotations (tasks, events, states) for videos.
     Annotate(AnnotateArgs),
+    /// Remove indexed videos, or free the disk they and their caches use.
+    Remove(RemoveArgs),
+    /// Print a shell completion script, for example: cerul completions zsh.
+    ///
+    /// Hidden from the command list: it is run once when setting up a shell, and
+    /// every day after that it would only be a line to skip past.
+    #[command(hide = true)]
+    Completions {
+        /// Shell to generate for.
+        shell: clap_complete::Shell,
+    },
+}
+#[derive(Args)]
+struct AuthArgs {
+    #[command(subcommand)]
+    action: Option<AuthAction>,
+}
+#[derive(Subcommand)]
+enum AuthAction {
+    /// Enter and verify a Gemini API key, replacing any saved one.
+    Set,
+    /// Delete the saved Gemini API key.
+    Remove,
 }
 #[derive(Args)]
 struct AnnotateArgs {
+    /// Videos, directories, or LeRobot datasets.
     #[arg(required = true)]
     paths: Vec<PathBuf>,
-    #[arg(long,num_args=0..=1,default_missing_value="default")]
+    /// Semantic items to generate, comma-separated (default set when no value is given).
+    #[arg(long,num_args=0..=1,default_missing_value="default", value_name = "ITEMS")]
     semantic: Option<String>,
-    #[arg(long,num_args=0..=1,default_missing_value="default")]
-    grounding: Option<String>,
-    #[arg(long,num_args=0..=1,default_missing_value="default")]
-    world: Option<String>,
-    #[arg(long, default_value = "primary")]
-    streams: String,
-    #[arg(long)]
-    only: Option<String>,
-    #[arg(long)]
-    ontology: Option<PathBuf>,
-    #[arg(long,default_value="30s",value_parser=duration)]
-    window: i64,
-    #[arg(long, default_value_t = 2.)]
-    fps: f64,
-    #[arg(long, default_value_t = 4)]
-    jobs: usize,
-    #[arg(long)]
-    rpm: Option<u32>,
+    /// Write subtask annotations back into the LeRobot dataset.
     #[arg(long)]
     write_lerobot: bool,
-    #[arg(long)]
+    /// Directory for exported annotation files.
+    #[arg(long, value_name = "DIR")]
     out: Option<PathBuf>,
+    /// Custom ontology file.
+    #[arg(long, value_name = "FILE", help_heading = ADVANCED)]
+    ontology: Option<PathBuf>,
+    /// Model window length, for example 30s.
+    #[arg(long,default_value="30s",value_parser=duration, help_heading = ADVANCED)]
+    window: i64,
+    /// Frames per second sampled for the model.
+    #[arg(long, default_value_t = 2., help_heading = ADVANCED)]
+    fps: f64,
+    /// Parallel model requests.
+    #[arg(long, default_value_t = 4, help_heading = ADVANCED)]
+    jobs: usize,
+    /// Cap on model requests per minute.
+    #[arg(long, help_heading = ADVANCED)]
+    rpm: Option<u32>,
+    /// Streams to annotate, comma-separated.
+    #[arg(long, default_value = "primary", help_heading = ADVANCED)]
+    streams: String,
+    /// Only these episodes (ids or local indexes), comma-separated.
+    #[arg(long, help_heading = ADVANCED)]
+    only: Option<String>,
+    #[arg(long,num_args=0..=1,default_missing_value="default", hide = true)]
+    grounding: Option<String>,
+    #[arg(long,num_args=0..=1,default_missing_value="default", hide = true)]
+    world: Option<String>,
 }
 #[derive(Args)]
 struct SearchArgs {
+    /// What to look for, in plain words, wrapped in quotes.
     query: Option<String>,
-    #[arg(long, conflicts_with = "query")]
+    #[arg(hide = true, trailing_var_arg = true, num_args = 0..)]
+    extra_words: Vec<String>,
+    /// Search with a reference image instead of words.
+    #[arg(long, conflicts_with = "query", value_name = "FILE")]
     image: Option<PathBuf>,
+    /// Match the exact words in screen text or speech instead of by meaning.
     #[arg(long)]
     text: bool,
-    #[arg(long = "filter")]
-    filters: Vec<String>,
-    #[arg(long = "in")]
-    within: Option<PathBuf>,
-    #[arg(long, default_value_t = 10)]
-    limit: usize,
-    #[arg(long)]
-    threshold: Option<f32>,
-    #[arg(long)]
-    count: bool,
-    #[arg(long)]
+    /// Save each matching moment as an MP4 clip in this directory.
+    #[arg(long, value_name = "DIR")]
     save: Option<PathBuf>,
-    #[arg(long,default_value="2s",value_parser=duration)]
+    /// Show a still frame for each result (default when the terminal supports images).
+    #[arg(long, conflicts_with = "no_preview")]
+    preview: bool,
+    /// Never show still frames.
+    #[arg(long)]
+    no_preview: bool,
+    /// Maximum number of results.
+    #[arg(long, default_value_t = 10, value_name = "N")]
+    limit: usize,
+    /// Only search videos under this path.
+    #[arg(long = "in", value_name = "PATH")]
+    within: Option<PathBuf>,
+    /// Seconds of context added before and after each saved clip.
+    #[arg(long,default_value="2s",value_parser=duration, value_name = "DURATION")]
     pad: i64,
+    /// Restrict by annotation field, for example semantic.event.verb=pour.
+    #[arg(long = "filter", value_name = "KEY=VALUE", help_heading = ADVANCED)]
+    filters: Vec<String>,
+    /// Minimum similarity score for semantic matches.
+    #[arg(long, help_heading = ADVANCED)]
+    threshold: Option<f32>,
+    /// Count matching intervals instead of listing them.
+    #[arg(long, help_heading = ADVANCED)]
+    count: bool,
 }
 #[derive(Args)]
-struct CleanArgs {
-    #[arg(long, conflicts_with_all=["all_indexes", "compact"])]
-    index: Option<String>,
-    #[arg(long, conflicts_with = "compact")]
-    all_indexes: bool,
+struct RemoveArgs {
+    /// Videos or directories to forget. Their files are left where they are.
+    paths: Vec<PathBuf>,
+    /// Free cached previews, query vectors, and media proxies; all regenerated.
     #[arg(long)]
     cache: bool,
-    #[arg(long)]
+    /// Free every search index; each rebuilds from sidecars with no model calls.
+    #[arg(long, conflicts_with = "compact")]
+    all_indexes: bool,
+    /// Free one search index by space id; rebuilt from sidecars on next use.
+    #[arg(long, conflicts_with_all=["all_indexes", "compact"], value_name = "SPACE", help_heading = ADVANCED)]
+    index: Option<String>,
+    /// Reclaim space inside search indexes without dropping them.
+    #[arg(long, help_heading = ADVANCED)]
     compact: bool,
-    #[arg(long)]
-    sidecars: Option<PathBuf>,
 }
 #[derive(Args)]
 struct IndexArgs {
+    /// Videos, directories, or LeRobot datasets.
     #[arg(required = true)]
     paths: Vec<PathBuf>,
-    #[arg(long, default_value="30s", value_parser=duration)]
-    chunk: i64,
-    #[arg(long, default_value="5s", value_parser=duration)]
-    overlap: i64,
+    /// Skip speech transcription.
     #[arg(long)]
     no_audio: bool,
+    /// Skip screen text recognition.
     #[arg(long)]
     no_ocr: bool,
-    #[arg(long)]
+    /// Length of each searchable window, for example 30s.
+    #[arg(long, default_value="30s", value_parser=duration, value_name = "DURATION", help_heading = ADVANCED)]
+    chunk: i64,
+    /// Overlap between windows.
+    #[arg(long, default_value="5s", value_parser=duration, value_name = "DURATION", help_heading = ADVANCED)]
+    overlap: i64,
+    /// Skip windows where the picture does not change.
+    #[arg(long, help_heading = ADVANCED)]
     skip_still: bool,
-    #[arg(long, default_value = "primary")]
+    /// Streams to index, comma-separated.
+    #[arg(long, default_value = "primary", help_heading = ADVANCED)]
     streams: String,
-    #[arg(long)]
+    /// Only these episodes (ids or local indexes), comma-separated.
+    #[arg(long, help_heading = ADVANCED)]
     only: Option<String>,
-    #[arg(long, default_value_t = 4)]
+    /// Parallel model requests.
+    #[arg(long, default_value_t = 4, help_heading = ADVANCED)]
     jobs: usize,
-    #[arg(long)]
+    /// Cap on model requests per minute.
+    #[arg(long, help_heading = ADVANCED)]
     rpm: Option<u32>,
-    #[arg(long)]
+    /// Store sidecars here instead of beside the videos.
+    #[arg(long, value_name = "DIR", help_heading = ADVANCED)]
     sidecar_dir: Option<PathBuf>,
 }
 fn duration(raw: &str) -> std::result::Result<i64, String> {
@@ -194,27 +303,151 @@ fn exit_code(error: &anyhow::Error) -> u8 {
         _ => 4,
     }
 }
-fn event(json: bool, quiet: bool, value: Event) {
-    let mut out = io::stderr().lock();
-    if json {
-        let _ = serde_json::to_writer(&mut out, &value);
-        let _ = writeln!(out);
-    } else if !quiet {
-        match value {
-            Event::Log { level, msg } => {
-                let _ = writeln!(out, "{level}: {msg}");
+
+/// Everything a command can produce. JSON mode serializes it; human mode renders it.
+enum Outcome {
+    Home(cerul::status::Status, render::ModelSummary),
+    Status {
+        status: cerul::status::Status,
+        models: render::ModelSummary,
+        probed: bool,
+    },
+    Auth(render::KeyState, Option<&'static str>),
+    Remove(
+        cerul::clean::Report,
+        BTreeMap<String, PathBuf>,
+        Vec<PathBuf>,
+    ),
+    Open {
+        media: PathBuf,
+        start_us: i64,
+        player: String,
+        seeks: bool,
+        opened: bool,
+    },
+    Index(pipeline::Report, BTreeMap<String, PathBuf>),
+    Search(cerul::search::Report, render::SearchContext),
+    Annotate(cerul::annotate::pipeline::Report, BTreeMap<String, PathBuf>),
+}
+impl Outcome {
+    fn json(&self) -> Result<Value> {
+        Ok(match self {
+            Outcome::Home(status, _) | Outcome::Status { status, .. } => {
+                serde_json::to_value(status)?
             }
-            Event::Progress {
-                episode,
-                station,
-                done,
-                total,
+            Outcome::Auth(key, action) => {
+                let mut value = serde_json::to_value(key)?;
+                if let Some(action) = action {
+                    value["action"] = json!(action);
+                }
+                value
+            }
+            Outcome::Open {
+                media,
+                start_us,
+                player,
+                seeks,
+                opened,
             } => {
-                let _ = writeln!(out, "{episode} {station}: {done}/{total}");
+                json!({"media": media, "start_us": start_us, "player": player, "seeks": seeks, "opened": opened})
             }
+            Outcome::Index(report, _) => serde_json::to_value(report)?,
+            Outcome::Search(report, _) => serde_json::to_value(report)?,
+            Outcome::Remove(report, _, _) => serde_json::to_value(report)?,
+            Outcome::Annotate(report, _) => serde_json::to_value(report)?,
+        })
+    }
+    fn render(&self, out: &mut dyn Write, palette: &Palette) -> io::Result<()> {
+        match self {
+            Outcome::Home(status, models) => render::home(out, palette, status, models),
+            Outcome::Status {
+                status,
+                models,
+                probed,
+            } => render::status(out, palette, status, models, *probed),
+            Outcome::Auth(key, action) => {
+                match action {
+                    Some("set") => {
+                        writeln!(out, "{} Gemini key saved.", palette.ok("✓"))?;
+                        writeln!(out)?;
+                        writeln!(
+                            out,
+                            "Next: {}   {}",
+                            palette.cmd("cerul index ./video.mp4"),
+                            palette.dim("index a video, then search it")
+                        )?;
+                    }
+                    Some("removed") => {
+                        writeln!(out, "{} Saved Gemini key removed.", palette.ok("✓"))?
+                    }
+                    Some("absent") => writeln!(out, "No saved Gemini key to remove.")?,
+                    _ => {}
+                }
+                if action.is_none() || matches!(action, Some("absent")) {
+                    render::auth(out, palette, key)
+                } else {
+                    Ok(())
+                }
+            }
+            Outcome::Open {
+                media,
+                start_us,
+                player,
+                seeks,
+                opened,
+            } => render::open(out, palette, media, *start_us, player, *seeks, *opened),
+            Outcome::Index(report, names) => render::index(out, palette, report, names),
+            Outcome::Search(report, context) => render::search(out, palette, report, context),
+            Outcome::Remove(report, names, unknown) => {
+                render::remove(out, palette, report, names, unknown)
+            }
+            Outcome::Annotate(report, names) => render::annotate(out, palette, report, names),
         }
     }
 }
+
+/// Shared event sink: NDJSON on stderr for `--json`, rendered progress otherwise.
+#[derive(Clone)]
+struct Sink {
+    mode: Mode,
+    progress: Arc<Mutex<render::Progress>>,
+}
+impl Sink {
+    fn emit(&self, value: Event) {
+        match self.mode {
+            Mode::Json => {
+                let mut out = io::stderr().lock();
+                let _ = serde_json::to_writer(&mut out, &value);
+                let _ = writeln!(out);
+            }
+            Mode::Human => self.progress.lock().unwrap().handle(value),
+        }
+    }
+    fn finish(&self) {
+        if self.mode == Mode::Human {
+            self.progress.lock().unwrap().finish();
+        }
+    }
+    fn spinner(&self, message: &str) {
+        if self.mode == Mode::Human {
+            self.progress.lock().unwrap().start_spinner(message);
+        }
+    }
+    /// One privacy notice per endpoint before media leaves the machine.
+    fn notice(&self, verb: &'static str) -> cerul::providers::RequestNotice {
+        let sink = self.clone();
+        let seen = Mutex::new(BTreeSet::new());
+        Arc::new(move |endpoint| {
+            if seen.lock().unwrap().insert(endpoint.base_url.clone()) {
+                sink.emit(Event::Log {
+                    level: "info".into(),
+                    msg: format!("{verb} {}", endpoint.base_url),
+                });
+            }
+        })
+    }
+}
+
 fn config(cli: &Cli) -> Result<Config> {
     let mut overlay = toml::Table::new();
     for item in &cli.overrides {
@@ -244,7 +477,149 @@ fn config(cli: &Cli) -> Result<Config> {
         .collect();
     Config::resolve(&paths, &environment, toml::Value::Table(overlay))
 }
-async fn execute(cli: &Cli, cancel: CancellationToken) -> Result<(Value, u8)> {
+fn models(config: &Config) -> render::ModelSummary {
+    render::ModelSummary {
+        embedding: config.embedding.model.clone(),
+        embedding_dims: config.embedding.dims,
+        vision: config.vision.model.clone(),
+        transcription: config.transcription.model.clone(),
+        key: credentials::state(&config.embedding),
+    }
+}
+const QUOTES: &[char] = &['"', '\'', '\u{2018}', '\u{2019}', '\u{201C}', '\u{201D}'];
+/// Drops stray straight or curly quotes that end up inside the argument.
+fn query_words(query: &str) -> Option<String> {
+    let cleaned = query.trim().trim_matches(QUOTES).trim();
+    (!cleaned.is_empty()).then(|| cleaned.to_owned())
+}
+/// The last search, so `open N` can act on the numbers a person just read.
+#[derive(Serialize, Deserialize)]
+struct LastSearch {
+    query: Option<String>,
+    hits: Vec<LastHit>,
+}
+#[derive(Serialize, Deserialize)]
+struct LastHit {
+    media: Option<PathBuf>,
+    start_us: i64,
+    end_us: i64,
+}
+fn last_search_path(workspace: &Path) -> PathBuf {
+    workspace.join("cache").join("last-search.json")
+}
+
+/// How a moment will be opened, and whether the player honours the timestamp.
+struct Launch {
+    program: PathBuf,
+    arguments: Vec<String>,
+    name: String,
+    seeks: bool,
+}
+fn on_path(program: &str) -> Option<PathBuf> {
+    std::env::split_paths(&std::env::var_os("PATH")?)
+        .map(|directory| directory.join(program))
+        .find(|candidate| candidate.is_file())
+}
+/// Prefers players that can start at a timestamp, and says so when none can.
+fn launch(media: &Path, start_us: i64) -> Launch {
+    let seconds = format!("{:.3}", start_us.max(0) as f64 / 1_000_000.);
+    let media = media.to_string_lossy().into_owned();
+    let iina = PathBuf::from("/Applications/IINA.app/Contents/MacOS/iina-cli");
+    let candidates: [(Option<PathBuf>, &str, Vec<String>); 4] = [
+        (
+            on_path("mpv"),
+            "mpv",
+            vec![format!("--start={seconds}"), media.clone()],
+        ),
+        (
+            iina.is_file().then_some(iina),
+            "IINA",
+            vec![format!("--mpv-start={seconds}"), media.clone()],
+        ),
+        (
+            on_path("vlc"),
+            "VLC",
+            vec![format!("--start-time={seconds}"), media.clone()],
+        ),
+        (
+            on_path("ffplay"),
+            "ffplay",
+            vec![
+                "-loglevel".into(),
+                "error".into(),
+                "-ss".into(),
+                seconds.clone(),
+                "-autoexit".into(),
+                media.clone(),
+            ],
+        ),
+    ];
+    for (program, name, arguments) in candidates {
+        if let Some(program) = program {
+            return Launch {
+                program,
+                arguments,
+                name: name.into(),
+                seeks: true,
+            };
+        }
+    }
+    let fallback = if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        "xdg-open"
+    };
+    Launch {
+        program: on_path(fallback).unwrap_or_else(|| PathBuf::from(fallback)),
+        arguments: vec![media],
+        name: "the system player".into(),
+        seeks: false,
+    }
+}
+
+/// Distinguishes "this video was never indexed" from a real planning failure.
+fn is_unindexed(error: &anyhow::Error) -> bool {
+    format!("{error:#}").contains("no registered sidecars match selection")
+}
+
+/// Asks before an irreversible removal. A non-terminal caller must pass --yes,
+/// so a script never destroys an index because nobody was there to answer.
+fn confirm(action: &str, question: &str) -> Result<bool> {
+    use std::io::{BufRead, IsTerminal};
+    anyhow::ensure!(
+        io::stdin().is_terminal() && io::stderr().is_terminal(),
+        CliError(2, format!("{action} needs confirmation"))
+    );
+    eprint!("{question} [y/N] ");
+    io::stderr().flush()?;
+    let mut answer = String::new();
+    io::stdin().lock().read_line(&mut answer)?;
+    Ok(matches!(answer.trim().to_lowercase().as_str(), "y" | "yes"))
+}
+
+/// Rejects unreadable inputs before any plan, model request, or progress output.
+fn readable(paths: &[PathBuf]) -> Result<()> {
+    for path in paths {
+        anyhow::ensure!(
+            path.exists(),
+            CliError(2, format!("no such file or directory: {}", path.display()))
+        );
+    }
+    Ok(())
+}
+fn names(workspace: &Path) -> BTreeMap<String, PathBuf> {
+    discover::read_registry(workspace)
+        .map(|entries| {
+            entries
+                .into_iter()
+                .map(|entry| (entry.episode_id, entry.media))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+const MEDIA_NOTICE: &str = "Using Gemini (media may be sent, usage billed to your key):";
+
+async fn execute(cli: &Cli, sink: &Sink, cancel: CancellationToken) -> Result<(Outcome, u8)> {
     let workspace = cli
         .workspace
         .clone()
@@ -257,6 +632,120 @@ async fn execute(cli: &Cli, cancel: CancellationToken) -> Result<(Value, u8)> {
         })
         .map_err(|e| category(2, e))?;
     match &cli.command {
+        None => {
+            let status = cerul::status::inspect(&workspace, None)?;
+            let config = config(cli).map_err(|e| category(2, e))?;
+            Ok((Outcome::Home(status, models(&config)), 0))
+        }
+        Some(Command::Status { path, providers }) => {
+            let mut status = cerul::status::inspect(&workspace, path.as_deref())?;
+            let config = config(cli).map_err(|e| category(2, e))?;
+            let mut partial = false;
+            if *providers && !cli.dry_run {
+                partial = cerul::status::check_providers(
+                    &mut status,
+                    &config,
+                    cancel,
+                    (!cli.yes).then(|| {
+                        sink.notice("Checking endpoint capabilities with small test inputs:")
+                    }),
+                    cli.recompute,
+                )
+                .await?;
+            }
+            sink.finish();
+            Ok((
+                Outcome::Status {
+                    status,
+                    models: models(&config),
+                    probed: *providers && !cli.dry_run,
+                },
+                if partial { 6 } else { 0 },
+            ))
+        }
+        Some(Command::Open { number }) => {
+            let path = last_search_path(&workspace);
+            let last: LastSearch = fs::read(&path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+                .ok_or_else(|| {
+                    CliError(2, "no recent search to open; run cerul search first".into())
+                })?;
+            anyhow::ensure!(
+                (1..=last.hits.len()).contains(number),
+                CliError(
+                    2,
+                    format!(
+                        "the last search returned {} result{}",
+                        last.hits.len(),
+                        if last.hits.len() == 1 { "" } else { "s" }
+                    )
+                )
+            );
+            let hit = &last.hits[number - 1];
+            let media = hit
+                .media
+                .clone()
+                .context("that result has no video file")
+                .map_err(|e| category(2, e))?;
+            anyhow::ensure!(
+                media.is_file(),
+                CliError(2, format!("the video has moved: {}", media.display()))
+            );
+            let plan = launch(&media, hit.start_us);
+            if !cli.dry_run {
+                std::process::Command::new(&plan.program)
+                    .args(&plan.arguments)
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .with_context(|| format!("could not start {}", plan.name))
+                    .map_err(|e| category(4, e))?;
+            }
+            Ok((
+                Outcome::Open {
+                    media,
+                    start_us: hit.start_us,
+                    player: plan.name,
+                    seeks: plan.seeks,
+                    opened: !cli.dry_run,
+                },
+                0,
+            ))
+        }
+        Some(Command::Auth(args)) => {
+            let config = config(cli).map_err(|e| category(2, e))?;
+            let endpoint = &config.embedding;
+            let action = match args.action {
+                None => None,
+                Some(AuthAction::Set) => {
+                    anyhow::ensure!(
+                        !cli.json && !cli.yes && !cli.dry_run,
+                        CliError(
+                            2,
+                            format!(
+                                "cerul auth set is interactive; export {} for scripts",
+                                endpoint.api_key_env
+                            )
+                        )
+                    );
+                    credentials::set(endpoint, cancel)
+                        .await
+                        .map_err(|e| category(2, e))?;
+                    Some("set")
+                }
+                Some(AuthAction::Remove) => {
+                    if cli.dry_run {
+                        None
+                    } else if credentials::remove(endpoint).map_err(|e| category(2, e))? {
+                        Some("removed")
+                    } else {
+                        Some("absent")
+                    }
+                }
+            };
+            Ok((Outcome::Auth(credentials::state(endpoint), action), 0))
+        }
         Some(Command::Annotate(args)) => {
             if args.grounding.is_some() || args.world.is_some() {
                 return Err(ProviderError {
@@ -273,24 +762,6 @@ async fn execute(cli: &Cli, cancel: CancellationToken) -> Result<(Value, u8)> {
                 )
             );
             let config = config(cli).map_err(|e| category(2, e))?;
-            let json = cli.json;
-            let quiet = cli.quiet;
-            let seen = Mutex::new(BTreeSet::new());
-            let notice: cerul::providers::RequestNotice = Arc::new(move |endpoint| {
-                if seen.lock().unwrap().insert(endpoint.base_url.clone()) {
-                    event(
-                        json,
-                        false,
-                        Event::Log {
-                            level: "info".into(),
-                            msg: format!(
-                                "Sending model requests, including media when needed, to {}",
-                                endpoint.base_url
-                            ),
-                        },
-                    );
-                }
-            });
             let items = match args.semantic.as_deref() {
                 Some("default") => Vec::new(),
                 Some(value) => value.split(',').map(str::to_owned).collect(),
@@ -309,43 +780,45 @@ async fn execute(cli: &Cli, cancel: CancellationToken) -> Result<(Value, u8)> {
                 dry_run: cli.dry_run,
                 jobs: args.jobs,
                 rpm: args.rpm,
-                request_notice: (!cli.yes).then_some(notice),
+                request_notice: (!cli.yes).then(|| sink.notice(MEDIA_NOTICE)),
             };
             options.validate().map_err(|e| category(2, e))?;
+            readable(&args.paths)?;
             cerul::media::check_dependencies().map_err(|e| category(3, e))?;
+            let events = sink.clone();
             let report = cerul::annotate::pipeline::run(
                 &args.paths,
                 &workspace,
                 &config,
                 &options,
                 cancel,
-                &mut |value| event(json, quiet, value),
+                &mut |value| events.emit(value),
             )
             .await?;
+            sink.finish();
             let code = if report.partial { 6 } else { 0 };
-            Ok((serde_json::to_value(report)?, code))
+            Ok((Outcome::Annotate(report, names(&workspace)), code))
         }
         Some(Command::Search(args)) => {
             let config = config(cli).map_err(|e| category(2, e))?;
-            let json = cli.json;
-            let seen = Mutex::new(BTreeSet::new());
-            let notice: cerul::providers::RequestNotice = Arc::new(move |endpoint| {
-                if seen.lock().unwrap().insert(endpoint.base_url.clone()) {
-                    event(
-                        json,
-                        false,
-                        Event::Log {
-                            level: "info".into(),
-                            msg: format!(
-                                "Sending model requests, including media when needed, to {}",
-                                endpoint.base_url
-                            ),
-                        },
-                    );
-                }
-            });
+            anyhow::ensure!(
+                args.extra_words.is_empty(),
+                CliError(
+                    2,
+                    format!(
+                        "the query must be one quoted argument, for example: cerul search \"{} {}\"",
+                        args.query.clone().unwrap_or_default().trim_matches(QUOTES),
+                        args.extra_words.join(" ").trim_matches(QUOTES)
+                    )
+                )
+            );
+            let query = args.query.as_deref().and_then(query_words);
+            let terminal = render::Terminal::detect(sink.mode);
+            let preview = !args.no_preview
+                && !cli.dry_run
+                && (args.preview || (terminal.images.is_some() && !cli.quiet));
             let options = cerul::search::Options {
-                query: args.query.clone(),
+                query: query.clone(),
                 image: args.image.clone(),
                 text: args.text,
                 filters: args.filters.clone(),
@@ -354,73 +827,179 @@ async fn execute(cli: &Cli, cancel: CancellationToken) -> Result<(Value, u8)> {
                 threshold: args.threshold,
                 count: args.count,
                 save: args.save.clone(),
+                preview,
                 pad_us: args.pad,
                 dry_run: cli.dry_run,
-                request_notice: (!cli.yes).then_some(notice),
+                request_notice: (!cli.yes).then(|| sink.notice(MEDIA_NOTICE)),
             };
             options.validate().map_err(|e| category(2, e))?;
-            Ok((
-                serde_json::to_value(
-                    cerul::search::run(&workspace, &config, &options, cancel).await?,
-                )?,
-                0,
-            ))
-        }
-        Some(Command::Clean(args)) => {
-            let options = cerul::clean::Options {
-                index: args.index.clone(),
-                all_indexes: args.all_indexes,
-                cache: args.cache,
-                compact: args.compact,
-                sidecars: args.sidecars.clone(),
-                yes: cli.yes,
-                dry_run: cli.dry_run,
-            };
-            cerul::clean::plan(&workspace, &options).map_err(|e| category(2, e))?;
-            Ok((
-                serde_json::to_value(
-                    cerul::clean::run_with_cancellation(&workspace, &options, cancel).await?,
-                )?,
-                0,
-            ))
-        }
-        Some(Command::Status { path, providers }) => {
-            let mut status = cerul::status::inspect(&workspace, path.as_deref())?;
-            let mut partial = false;
-            if *providers && !cli.dry_run {
-                let config = config(cli).map_err(|e| category(2, e))?;
-                let json = cli.json;
-                let seen = Mutex::new(BTreeSet::new());
-                let notice: cerul::providers::RequestNotice = Arc::new(move |endpoint| {
-                    if seen.lock().unwrap().insert(endpoint.base_url.clone()) {
-                        event(
-                            json,
-                            false,
-                            Event::Log {
-                                level: "info".into(),
-                                msg: format!(
-                                    "Checking endpoint capabilities with small test inputs: {}",
-                                    endpoint.base_url
-                                ),
-                            },
-                        );
-                    }
-                });
-                partial = cerul::status::check_providers(
-                    &mut status,
-                    &config,
-                    cancel,
-                    (!cli.yes).then_some(notice),
-                    cli.recompute,
-                )
-                .await?;
+            sink.spinner("Searching…");
+            let report = cerul::search::run(&workspace, &config, &options, cancel).await;
+            sink.finish();
+            let report = report?;
+            // Remembering the numbers a person just read is what makes `open N` work.
+            if !cli.dry_run && !report.hits.is_empty() {
+                let last = LastSearch {
+                    query: query.clone(),
+                    hits: report
+                        .hits
+                        .iter()
+                        .map(|hit| LastHit {
+                            media: hit.media.clone(),
+                            start_us: hit.start_us,
+                            end_us: hit.end_us,
+                        })
+                        .collect(),
+                };
+                let path = last_search_path(&workspace);
+                if fs::create_dir_all(path.parent().expect("cache path has a parent")).is_ok() {
+                    let _ = cerul::storage::write_json(&path, &last);
+                }
             }
-            Ok((serde_json::to_value(status)?, if partial { 6 } else { 0 }))
+            Ok((
+                Outcome::Search(
+                    report,
+                    render::SearchContext {
+                        query,
+                        image: args.image.clone(),
+                        text: args.text,
+                        saved_to: args.save.clone(),
+                        terminal,
+                        player: render::Player::detect(),
+                    },
+                ),
+                0,
+            ))
         }
-        None => Ok((
-            serde_json::to_value(cerul::status::inspect(&workspace, None)?)?,
-            0,
-        )),
+        Some(Command::Completions { .. }) => {
+            unreachable!("completions are printed before the runtime starts")
+        }
+        Some(Command::Remove(args)) => {
+            anyhow::ensure!(
+                !args.paths.is_empty()
+                    || args.cache
+                    || args.all_indexes
+                    || args.index.is_some()
+                    || args.compact,
+                CliError(
+                    2,
+                    "name the videos to forget, or pass --cache or --all-indexes".into()
+                )
+            );
+            readable(&args.paths)?;
+            let names = names(&workspace);
+            let wants_disposable =
+                args.cache || args.all_indexes || args.index.is_some() || args.compact;
+            // Plan every path first so one unknown video cannot leave a partial
+            // removal behind, and so the question names what will actually go.
+            let mut planned = Vec::new();
+            let mut unknown = Vec::new();
+            // No workspace means no registry, so nothing can be indexed yet.
+            let anything_indexed = workspace.exists();
+            for path in &args.paths {
+                if !anything_indexed {
+                    unknown.push(path.clone());
+                    continue;
+                }
+                let options = cerul::clean::Options {
+                    sidecars: Some(path.clone()),
+                    yes: true,
+                    dry_run: true,
+                    ..Default::default()
+                };
+                match cerul::clean::plan(&workspace, &options) {
+                    Ok(report) => planned.extend(report.items),
+                    // Forgetting something already forgotten is not a failure.
+                    Err(error) if is_unindexed(&error) => unknown.push(path.clone()),
+                    Err(error) => return Err(category(2, error)),
+                }
+            }
+            // Only losing a video needs a question; everything else grows back.
+            if !planned.is_empty() && !cli.dry_run && !cli.yes {
+                let listed = planned
+                    .iter()
+                    .filter_map(|item| item.episode.as_ref())
+                    .filter_map(|episode| names.get(episode))
+                    .map(|media| render::file_name(media))
+                    .collect::<Vec<_>>();
+                let subject = if listed.is_empty() {
+                    format!("{} episodes", planned.len())
+                } else {
+                    listed.join(", ")
+                };
+                let single = listed.len() == 1;
+                let action = format!("removing the index for {subject}");
+                let question = format!(
+                    "Remove the index for {subject}? The video file{} stay{} where {} {}.",
+                    if single { "" } else { "s" },
+                    if single { "s" } else { "" },
+                    if single { "it" } else { "they" },
+                    if single { "is" } else { "are" }
+                );
+                if !confirm(&action, &question).map_err(|e| category(2, e))? {
+                    return Ok((
+                        Outcome::Remove(
+                            cerul::clean::Report {
+                                dry_run: true,
+                                items: Vec::new(),
+                            },
+                            names,
+                            unknown,
+                        ),
+                        0,
+                    ));
+                }
+            }
+            let mut items = Vec::new();
+            if wants_disposable {
+                let options = cerul::clean::Options {
+                    index: args.index.clone(),
+                    all_indexes: args.all_indexes,
+                    cache: args.cache,
+                    compact: args.compact,
+                    sidecars: None,
+                    yes: true,
+                    dry_run: cli.dry_run,
+                };
+                cerul::clean::plan(&workspace, &options).map_err(|e| category(2, e))?;
+                items.extend(
+                    cerul::clean::run_with_cancellation(&workspace, &options, cancel.clone())
+                        .await?
+                        .items,
+                );
+            }
+            if cli.dry_run {
+                items.extend(planned);
+            } else {
+                for path in &args.paths {
+                    if unknown.contains(path) {
+                        continue;
+                    }
+                    let options = cerul::clean::Options {
+                        sidecars: Some(path.clone()),
+                        yes: true,
+                        dry_run: false,
+                        ..Default::default()
+                    };
+                    items.extend(
+                        cerul::clean::run_with_cancellation(&workspace, &options, cancel.clone())
+                            .await?
+                            .items,
+                    );
+                }
+            }
+            Ok((
+                Outcome::Remove(
+                    cerul::clean::Report {
+                        dry_run: cli.dry_run,
+                        items,
+                    },
+                    names,
+                    unknown,
+                ),
+                0,
+            ))
+        }
         Some(Command::Index(args)) => {
             let config = config(cli).map_err(|e| category(2, e))?;
             anyhow::ensure!(
@@ -432,25 +1011,19 @@ async fn execute(cli: &Cli, cancel: CancellationToken) -> Result<(Value, u8)> {
                 args.chunk <= 32_000_000,
                 CliError(2, "chunk must be at most 32s".into())
             );
+            readable(&args.paths)?;
             cerul::media::check_dependencies().map_err(|e| category(3, e))?;
-            let json = cli.json;
-            let quiet = cli.quiet;
-            let seen = Mutex::new(BTreeSet::new());
-            let notice: cerul::providers::RequestNotice = Arc::new(move |endpoint| {
-                if seen.lock().unwrap().insert(endpoint.base_url.clone()) {
-                    event(
-                        json,
-                        false,
-                        Event::Log {
-                            level: "info".into(),
-                            msg: format!(
-                                "Sending model requests, including media when needed, to {}",
-                                endpoint.base_url
-                            ),
-                        },
-                    );
-                }
-            });
+            if sink.mode == Mode::Human && !cli.quiet && !cli.dry_run {
+                let palette = Palette::new(console::colors_enabled_stderr());
+                let _ = render::index_plan(
+                    &mut io::stderr(),
+                    &palette,
+                    &args.paths,
+                    args.no_ocr,
+                    args.no_audio,
+                );
+            }
+            let events = sink.clone();
             let report = pipeline::run(
                 &args.paths,
                 &workspace,
@@ -470,29 +1043,74 @@ async fn execute(cli: &Cli, cancel: CancellationToken) -> Result<(Value, u8)> {
                     rpm: args.rpm,
                     sidecar_dir: args.sidecar_dir.clone(),
                     dry_run: cli.dry_run,
-                    request_notice: (!cli.yes).then_some(notice),
+                    request_notice: (!cli.yes).then(|| sink.notice(MEDIA_NOTICE)),
                 },
                 cancel,
-                &mut |value| event(json, quiet, value),
+                &mut |value| events.emit(value),
             )
             .await?;
+            sink.finish();
             let code = if report.partial { 6 } else { 0 };
-            Ok((serde_json::to_value(report)?, code))
+            Ok((Outcome::Index(report, names(&workspace)), code))
         }
     }
 }
-fn output(value: &Value, json: bool, quiet: bool) -> io::Result<()> {
-    if quiet && !json {
-        return Ok(());
-    }
+
+fn write_json(value: &Value) -> io::Result<()> {
     let mut out = io::stdout().lock();
-    if json {
-        serde_json::to_writer(&mut out, value).map_err(io::Error::other)?;
-    } else {
-        serde_json::to_writer_pretty(&mut out, value).map_err(io::Error::other)?;
-    }
+    serde_json::to_writer(&mut out, value).map_err(io::Error::other)?;
     writeln!(out)
 }
+
+/// A recovery hint for people; the JSON protocol carries only code and message.
+fn hint(code: u8, error: &anyhow::Error, env: &str) -> Option<String> {
+    let message = format!("{error:#}").to_lowercase();
+    if matches!(
+        error.downcast_ref::<ProviderError>().map(|e| e.kind),
+        Some(Failure::MissingKey)
+    ) || message.contains("api key")
+    {
+        return Some(format!(
+            "run `cerul auth set` to save a Gemini key, or export {env}"
+        ));
+    }
+    if message.contains("ffmpeg") || message.contains("ffprobe") {
+        return Some(
+            "reinstall with `curl -fsSL https://cerul.ai/install.sh | sh`, or put ffmpeg 6+ on PATH"
+                .into(),
+        );
+    }
+    if message.contains("no usable saved vectors") {
+        return Some("index the videos with this model first: cerul index ./video.mp4".into());
+    }
+    if message.contains("no such file") || message.contains("not found") {
+        return Some("check the path; run `cerul status` to see what is indexed".into());
+    }
+    // A command that refused for a missing selection should name a working one.
+    if message.contains("needs confirmation") {
+        return Some("add --yes to confirm without being asked".into());
+    }
+    if message.contains("select --semantic") {
+        return Some("cerul annotate ./video.mp4 --semantic".into());
+    }
+    if message.contains("--count requires") {
+        return Some("cerul search --filter 'semantic.event.verb=place' --count".into());
+    }
+    if message.contains("select an index, cache, compaction, or sidecar target")
+        || message.contains("name the videos to forget")
+    {
+        return Some("cerul remove ./video.mp4, or cerul remove --cache".into());
+    }
+    if message.contains("query, image, or filter is required") {
+        return Some("cerul search \"describe the moment\"".into());
+    }
+    match code {
+        2 => Some("see `cerul --help` for usage and `cerul status` for configuration".into()),
+        3 => Some("this build cannot do that yet; see `cerul status --providers`".into()),
+        _ => None,
+    }
+}
+
 #[tokio::main]
 async fn main() -> std::process::ExitCode {
     let arguments: Vec<_> = std::env::args_os().collect();
@@ -508,16 +1126,44 @@ async fn main() -> std::process::ExitCode {
                 return std::process::ExitCode::SUCCESS;
             }
             if json {
-                let _ = output(
+                let _ = write_json(
                     &json!({"error":{"code":"invalid_arguments","message":error.to_string()}}),
-                    true,
-                    false,
                 );
             } else {
                 let _ = error.print();
             }
             return std::process::ExitCode::from(2);
         }
+    };
+    if let Some(Command::Completions { shell }) = cli.command {
+        let mut command = Cli::command();
+        let name = command.get_name().to_string();
+        // The generator panics on any write error, so it never touches stdout
+        // directly: piping the script into `head` is ordinary shell use.
+        let mut script = Vec::new();
+        clap_complete::generate(shell, &mut command, name, &mut script);
+        return match io::stdout().write_all(&script) {
+            Ok(()) => std::process::ExitCode::SUCCESS,
+            Err(error) if error.kind() == io::ErrorKind::BrokenPipe => {
+                std::process::ExitCode::SUCCESS
+            }
+            Err(_) => std::process::ExitCode::from(4),
+        };
+    }
+    let mode = if cli.json { Mode::Json } else { Mode::Human };
+    let palette = Palette::new(mode == Mode::Human && console::colors_enabled());
+    let workspace_hint = cli
+        .workspace
+        .clone()
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cerul")))
+        .unwrap_or_default();
+    let sink = Sink {
+        mode,
+        progress: Arc::new(Mutex::new(render::Progress::new(
+            &workspace_hint,
+            cli.quiet,
+            Palette::new(mode == Mode::Human && console::colors_enabled_stderr()),
+        ))),
     };
     let cancel = CancellationToken::new();
     let signal = cancel.clone();
@@ -528,35 +1174,66 @@ async fn main() -> std::process::ExitCode {
     });
     let result = cerul::media::with_cancellation(cancel.clone(), async {
         let resolver = credentials::resolver(&cli, cancel.clone());
-        cerul::providers::with_credential_resolver(resolver, execute(&cli, cancel.clone())).await
+        cerul::providers::with_credential_resolver(resolver, execute(&cli, &sink, cancel.clone()))
+            .await
     })
     .await;
     listener.abort();
-    let (value, code) = match result {
-        Ok(result) if !cancel.is_cancelled() => result,
-        Ok(_) => (
-            json!({"error":{"code":"cancelled","message":"operation cancelled"}}),
-            5,
-        ),
+    sink.finish();
+    let failure = |code: u8, message: String| {
+        let name = match code {
+            2 => "invalid_configuration",
+            3 => "missing_capability",
+            5 => "cancelled",
+            _ => "execution_failed",
+        };
+        (name, message)
+    };
+    let (outcome, code, error) = match result {
+        Ok((outcome, code)) if !cancel.is_cancelled() => (Some(outcome), code, None),
+        Ok(_) => (None, 5, Some(failure(5, "operation cancelled".into()))),
         Err(error) => {
             let code = if cancel.is_cancelled() {
                 5
             } else {
                 exit_code(&error)
             };
-            let name = match code {
-                2 => "invalid_configuration",
-                3 => "missing_capability",
-                5 => "cancelled",
-                _ => "execution_failed",
+            let env = config(&cli)
+                .map(|c| c.embedding.api_key_env)
+                .unwrap_or_else(|_| "GEMINI_API_KEY".into());
+            let hint = if code == 5 {
+                None
+            } else {
+                hint(code, &error, &env)
             };
-            (
-                json!({"error":{"code":name,"message":format!("{error:#}")}}),
-                code,
-            )
+            let mut named = failure(code, format!("{error:#}"));
+            if mode == Mode::Human {
+                eprintln!(
+                    "{}",
+                    render::error(&palette, code, &named.1, hint.as_deref())
+                );
+            }
+            named.1 = format!("{error:#}");
+            (None, code, Some(named))
         }
     };
-    match output(&value, cli.json, cli.quiet && code == 0) {
+    let written = match (mode, outcome, error) {
+        (Mode::Json, Some(outcome), _) => match outcome.json() {
+            Ok(value) => write_json(&value),
+            Err(error) => write_json(
+                &json!({"error":{"code":"execution_failed","message":error.to_string()}}),
+            ),
+        },
+        (Mode::Json, None, Some((name, message))) => {
+            write_json(&json!({"error":{"code":name,"message":message}}))
+        }
+        (Mode::Human, Some(outcome), _) if !cli.quiet || code != 0 => {
+            let mut out = io::stdout().lock();
+            outcome.render(&mut out, &palette).and_then(|_| out.flush())
+        }
+        _ => Ok(()),
+    };
+    match written {
         Ok(()) => std::process::ExitCode::from(code),
         Err(error) if error.kind() == io::ErrorKind::BrokenPipe => {
             std::process::ExitCode::from(code)

--- a/src/media/extract.rs
+++ b/src/media/extract.rs
@@ -94,6 +94,35 @@ pub fn video_quality(
     Ok(())
 }
 
+/// One still frame at a source timestamp, scaled for display. Input seeking keeps
+/// the cost independent of recording length, unlike exact frame selection.
+pub fn still(source: &Path, source_us: i64, destination: &Path, width: u32) -> Result<()> {
+    ensure!((16..=4096).contains(&width), "invalid still width");
+    let parent = destination.parent().context("still has no parent")?;
+    fs::create_dir_all(parent)?;
+    let temp = tempfile::Builder::new()
+        .suffix(".png")
+        .tempfile_in(parent)?;
+    let mut command = crate::media::command("ffmpeg");
+    seek_input(
+        &mut command,
+        source,
+        SourceRange::new(source_us, source_us.saturating_add(1))?,
+    )?;
+    command
+        .args([
+            "-frames:v",
+            "1",
+            "-vf",
+            &format!("scale='min({width},iw)':-2"),
+        ])
+        .arg(temp.path());
+    run(&mut command)?;
+    temp.as_file().sync_all()?;
+    temp.persist(destination).map_err(|e| e.error)?;
+    Ok(())
+}
+
 pub fn audio(source: &Path, source_range: SourceRange, destination: &Path) -> Result<()> {
     let parent = destination.parent().context("audio has no parent")?;
     fs::create_dir_all(parent)?;

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,1522 @@
+//! Human-readable terminal rendering for the CLI.
+//!
+//! Everything here is presentation only. The library emits structured values and
+//! events; this module turns them into text for people. `--json` bypasses it.
+use base64::{Engine, engine::general_purpose::STANDARD};
+use cerul::{
+    annotate, clean,
+    events::Event,
+    index::{self, discover, vectors::Kind},
+    search,
+    status::Status,
+};
+use console::{Style, measure_text_width, truncate_str};
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
+use std::{
+    collections::{BTreeMap, HashMap},
+    io::{self, IsTerminal, Write},
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+/// Optional terminal features. Both stay off unless the terminal advertises
+/// support, so ordinary terminals and redirected output never see escape codes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Terminal {
+    pub hyperlinks: bool,
+    pub images: Option<Images>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Images {
+    /// iTerm2 inline image protocol, also implemented by WezTerm.
+    Iterm,
+    /// Kitty graphics protocol, also implemented by Ghostty.
+    Kitty,
+}
+/// A media player that can start at a timestamp, when one is installed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Player {
+    /// IINA's URL scheme forwards mpv options, so a link can carry a start time.
+    Iina,
+    /// The system handler opens the file, always from the beginning.
+    System,
+}
+impl Player {
+    pub fn detect() -> Self {
+        if cfg!(target_os = "macos") && Path::new("/Applications/IINA.app").is_dir() {
+            Self::Iina
+        } else {
+            Self::System
+        }
+    }
+    /// A label and URL that open the moment itself where the player allows it.
+    pub fn open(&self, path: &Path, start_us: i64) -> (String, String) {
+        let file = url(path.to_string_lossy().as_ref(), b"/-_.~");
+        match self {
+            Self::Iina => (
+                format!("Open at {}", clock(start_us)),
+                format!(
+                    "iina://open?url={}&mpv_start={:.3}",
+                    url(&format!("file://{file}"), b"-_.~"),
+                    start_us.max(0) as f64 / 1_000_000.
+                ),
+            ),
+            Self::System => ("Open video".into(), format!("file://{file}")),
+        }
+    }
+}
+/// Percent-encodes everything outside the unreserved set given in `keep`.
+fn url(value: &str, keep: &[u8]) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || keep.contains(&byte) {
+            encoded.push(byte as char);
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+impl Terminal {
+    pub const fn none() -> Self {
+        Self {
+            hyperlinks: false,
+            images: None,
+        }
+    }
+    pub fn detect(mode: Mode) -> Self {
+        if mode == Mode::Json || !io::stdout().is_terminal() {
+            return Self::none();
+        }
+        let program = std::env::var("TERM_PROGRAM").unwrap_or_default();
+        let term = std::env::var("TERM").unwrap_or_default();
+        let kitty = term.contains("kitty")
+            || std::env::var_os("KITTY_WINDOW_ID").is_some()
+            || program == "ghostty";
+        let iterm = program == "iTerm.app" || program == "WezTerm";
+        let images = if kitty {
+            Some(Images::Kitty)
+        } else if iterm {
+            Some(Images::Iterm)
+        } else {
+            None
+        };
+        // VTE 0.50 and newer render OSC 8; older versions print the payload.
+        let vte = std::env::var("VTE_VERSION")
+            .ok()
+            .and_then(|value| value.parse::<u32>().ok())
+            .is_some_and(|version| version >= 5000);
+        let hyperlinks = images.is_some()
+            || vte
+            || matches!(program.as_str(), "vscode" | "Hyper" | "Tabby" | "rio");
+        Self { hyperlinks, images }
+    }
+    /// OSC 8 hyperlink, or the plain label when the terminal cannot render one.
+    pub fn link(&self, label: &str, target: &str) -> String {
+        if !self.hyperlinks {
+            return label.to_owned();
+        }
+        format!("\u{1b}]8;;{target}\u{7}{label}\u{1b}]8;;\u{7}")
+    }
+    pub fn file_link(&self, label: &str, path: &Path) -> String {
+        self.link(
+            label,
+            &format!("file://{}", url(path.to_string_lossy().as_ref(), b"/-_.~")),
+        )
+    }
+    /// Writes an inline image sized to fit `columns` by `rows` character cells.
+    fn image(&self, out: &mut dyn Write, path: &Path, columns: u32, rows: u32) -> io::Result<bool> {
+        let Some(protocol) = self.images else {
+            return Ok(false);
+        };
+        let Ok(bytes) = std::fs::read(path) else {
+            return Ok(false);
+        };
+        let payload = STANDARD.encode(&bytes);
+        match protocol {
+            Images::Iterm => write!(
+                out,
+                "\u{1b}]1337;File=inline=1;width={columns};height={rows};preserveAspectRatio=1;size={}:{payload}\u{7}",
+                bytes.len()
+            )?,
+            Images::Kitty => {
+                // The protocol caps each escape at 4096 base64 characters.
+                let chunks: Vec<&str> = payload
+                    .as_bytes()
+                    .chunks(4096)
+                    .map(|chunk| std::str::from_utf8(chunk).expect("base64 is ascii"))
+                    .collect();
+                for (index, chunk) in chunks.iter().enumerate() {
+                    let more = u8::from(index + 1 < chunks.len());
+                    if index == 0 {
+                        write!(
+                            out,
+                            "\u{1b}_Ga=T,f=100,c={columns},r={rows},m={more};{chunk}\u{1b}\\"
+                        )?;
+                    } else {
+                        write!(out, "\u{1b}_Gm={more};{chunk}\u{1b}\\")?;
+                    }
+                }
+            }
+        }
+        Ok(true)
+    }
+}
+
+/// How the process talks to the person or program that started it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Mode {
+    /// Final JSON on stdout, NDJSON events on stderr. Stable protocol for agents.
+    Json,
+    /// Text for people. Colour and live progress only when attached to a terminal.
+    Human,
+}
+
+/// Colour palette that degrades to plain text when colours are disabled.
+#[derive(Clone, Copy)]
+pub struct Palette {
+    enabled: bool,
+}
+impl Palette {
+    pub fn new(enabled: bool) -> Self {
+        Self { enabled }
+    }
+    fn paint(&self, style: Style, text: &str) -> String {
+        if self.enabled {
+            style.apply_to(text).to_string()
+        } else {
+            text.to_owned()
+        }
+    }
+    pub fn bold(&self, text: &str) -> String {
+        self.paint(Style::new().bold(), text)
+    }
+    pub fn dim(&self, text: &str) -> String {
+        self.paint(Style::new().dim(), text)
+    }
+    pub fn ok(&self, text: &str) -> String {
+        self.paint(Style::new().green(), text)
+    }
+    pub fn warn(&self, text: &str) -> String {
+        self.paint(Style::new().yellow(), text)
+    }
+    pub fn err(&self, text: &str) -> String {
+        self.paint(Style::new().red().bold(), text)
+    }
+    pub fn cmd(&self, text: &str) -> String {
+        self.paint(Style::new().cyan(), text)
+    }
+}
+
+/// What the person has configured for model access.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct KeyState {
+    pub provider: String,
+    pub endpoint: String,
+    pub env: String,
+    pub env_set: bool,
+    pub saved: bool,
+    pub credentials_path: Option<PathBuf>,
+}
+impl KeyState {
+    pub fn available(&self) -> bool {
+        self.env_set || self.saved
+    }
+    fn summary(&self, palette: &Palette) -> String {
+        if self.env_set {
+            palette.ok(&format!("key from ${}", self.env))
+        } else if self.saved {
+            palette.ok("key saved")
+        } else {
+            palette.warn("key not set")
+        }
+    }
+}
+
+/// Models the CLI would use, resolved from configuration for display.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ModelSummary {
+    pub embedding: String,
+    pub embedding_dims: Option<usize>,
+    pub vision: String,
+    pub transcription: String,
+    pub key: KeyState,
+}
+
+pub fn file_name(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+pub fn clock(us: i64) -> String {
+    let total = us.max(0) / 1_000_000;
+    let (hours, minutes, seconds) = (total / 3600, (total % 3600) / 60, total % 60);
+    if hours > 0 {
+        format!("{hours}:{minutes:02}:{seconds:02}")
+    } else {
+        format!("{minutes:02}:{seconds:02}")
+    }
+}
+
+fn station_label(station: &str) -> String {
+    match station {
+        "screen_text" => "Screen text".into(),
+        "transcript" => "Speech".into(),
+        "embed" => "Search index".into(),
+        other => {
+            let name = other.strip_prefix("semantic.").unwrap_or(other);
+            let mut chars = name.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => other.into(),
+            }
+        }
+    }
+}
+fn station_unit(station: &str, count: u64) -> String {
+    let (one, many) = match station {
+        "screen_text" => ("frame", "frames"),
+        "transcript" => ("segment", "segments"),
+        "embed" => ("batch", "batches"),
+        _ => ("window", "windows"),
+    };
+    format!("{count} {}", if count == 1 { one } else { many })
+}
+
+/// Renders progress events. Live bars on a terminal, one line per finished
+/// station otherwise, so redirected output never contains cursor movement.
+pub struct Progress {
+    palette: Palette,
+    quiet: bool,
+    workspace: PathBuf,
+    multi: Option<MultiProgress>,
+    bars: HashMap<(String, String), ProgressBar>,
+    /// Finished station summaries per episode, in completion order.
+    finished: HashMap<String, Vec<(String, String)>>,
+    /// The episode whose stations are currently on screen.
+    active: Option<String>,
+    spinner: Option<ProgressBar>,
+    names: HashMap<String, String>,
+    /// Episode ids already looked up, so a refresh happens once per new video.
+    resolved: std::collections::HashSet<String>,
+}
+impl Progress {
+    pub fn new(workspace: &Path, quiet: bool, palette: Palette) -> Self {
+        let animate = !quiet && io::stderr().is_terminal();
+        let multi = animate.then(|| MultiProgress::with_draw_target(ProgressDrawTarget::stderr()));
+        Self {
+            palette,
+            quiet,
+            workspace: workspace.to_owned(),
+            multi,
+            bars: HashMap::new(),
+            finished: HashMap::new(),
+            active: None,
+            spinner: None,
+            names: HashMap::new(),
+            resolved: std::collections::HashSet::new(),
+        }
+    }
+    fn name(&mut self, episode: &str) -> String {
+        if let Some(name) = self.names.get(episode) {
+            return name.clone();
+        }
+        // A video joins the registry as its turn begins, so an unknown id means
+        // the cached copy predates it. Refresh once per id, never per event.
+        if self.resolved.insert(episode.to_owned())
+            && let Ok(entries) = discover::read_registry(&self.workspace)
+        {
+            for entry in entries {
+                self.names
+                    .insert(entry.episode_id.clone(), file_name(&entry.media));
+            }
+        }
+        self.names
+            .get(episode)
+            .cloned()
+            .unwrap_or_else(|| episode.to_owned())
+    }
+    /// Replaces one episode's station bars with a single line, so indexing many
+    /// videos keeps the live area the size of the video being worked on.
+    fn collapse(&mut self, episode: &str) {
+        let Some(multi) = self.multi.clone() else {
+            return;
+        };
+        let mut removed = false;
+        self.bars.retain(|(id, _), bar| {
+            if id == episode {
+                multi.remove(bar);
+                removed = true;
+                return false;
+            }
+            true
+        });
+        let summaries = self.finished.remove(episode).unwrap_or_default();
+        if !removed || summaries.is_empty() {
+            return;
+        }
+        let name = self
+            .names
+            .get(episode)
+            .cloned()
+            .unwrap_or_else(|| episode.to_owned());
+        let line = summaries
+            .iter()
+            .map(|(_, text)| text.clone())
+            .collect::<Vec<_>>()
+            .join(&self.palette.dim("  ·  "));
+        let summary = format!(
+            "{} {}   {line}",
+            self.palette.ok("✓"),
+            self.palette.bold(&name)
+        );
+        // Printing above live bars relies on their redraw to end the line, so the
+        // last summary of a run must write its own newline instead.
+        if self.bars.is_empty() {
+            eprintln!("{summary}");
+        } else {
+            let _ = multi.println(summary);
+        }
+    }
+
+    /// Marks work whose duration cannot be predicted, such as one model request.
+    pub fn start_spinner(&mut self, message: &str) {
+        let Some(multi) = &self.multi else { return };
+        let bar = multi.add(ProgressBar::new_spinner());
+        bar.set_style(
+            ProgressStyle::with_template("  {spinner:.cyan} {msg} {elapsed}")
+                .expect("static template"),
+        );
+        bar.set_message(self.palette.dim(message));
+        bar.enable_steady_tick(Duration::from_millis(100));
+        self.spinner = Some(bar);
+    }
+    pub fn stop_spinner(&mut self) {
+        if let Some(bar) = self.spinner.take() {
+            bar.finish_and_clear();
+        }
+    }
+    pub fn println(&self, line: &str) {
+        if self.quiet {
+            return;
+        }
+        match &self.multi {
+            Some(multi) if !self.bars.is_empty() || self.spinner.is_some() => {
+                let _ = multi.println(line);
+            }
+            _ => eprintln!("{line}"),
+        }
+    }
+    pub fn handle(&mut self, event: Event) {
+        match event {
+            Event::Log { level, msg } => {
+                let line = match level.as_str() {
+                    "warn" | "warning" => format!("{} {msg}", self.palette.warn("!")),
+                    "error" => format!("{} {msg}", self.palette.err("✗")),
+                    _ => self.palette.dim(&format!("→ {msg}")),
+                };
+                self.println(&line);
+            }
+            Event::Progress {
+                episode,
+                station,
+                done,
+                total,
+            } => {
+                if self.quiet {
+                    return;
+                }
+                // Episodes are indexed one at a time, so the previous one is done.
+                if self.active.as_deref() != Some(episode.as_str()) {
+                    if let Some(previous) = self.active.take() {
+                        self.collapse(&previous);
+                    }
+                    self.active = Some(episode.clone());
+                }
+                let name = self.name(&episode);
+                let label = station_label(&station);
+                match &self.multi {
+                    Some(multi) => {
+                        // Only the first station of an episode repeats its name.
+                        let heading = !self.bars.keys().any(|(id, _)| id == &episode);
+                        let key = (episode.clone(), station.clone());
+                        let bar = self.bars.entry(key).or_insert_with(|| {
+                            let bar = multi.add(ProgressBar::new(total.max(1)));
+                            bar.set_style(
+                                ProgressStyle::with_template(
+                                    "  {spinner:.cyan} {prefix:<20!} {msg:<13} {bar:20.cyan/black} {pos}/{len} {elapsed}",
+                                )
+                                .expect("static template")
+                                .progress_chars("━╸─"),
+                            );
+                            bar.set_prefix(if heading {
+                                name.clone()
+                            } else {
+                                String::new()
+                            });
+                            bar.set_message(label.clone());
+                            bar.enable_steady_tick(Duration::from_millis(100));
+                            bar
+                        });
+                        bar.set_length(total.max(1));
+                        bar.set_position(done.min(total.max(1)));
+                        if done >= total {
+                            let unit = station_unit(&station, total);
+                            let summaries = self.finished.entry(episode.clone()).or_default();
+                            if !summaries.iter().any(|(name, _)| name == &station) {
+                                summaries.push((
+                                    station.clone(),
+                                    format!("{} {unit}", label.to_lowercase()),
+                                ));
+                            }
+                            bar.set_style(
+                                ProgressStyle::with_template("    {prefix:<20!} {msg}")
+                                    .expect("static template"),
+                            );
+                            bar.set_message(format!(
+                                "{} {:<13} {}",
+                                self.palette.ok("✓"),
+                                label,
+                                self.palette.dim(&unit)
+                            ));
+                            bar.finish();
+                        }
+                    }
+                    None => {
+                        if done >= total {
+                            eprintln!("  ✓ {name}  {label}  {}", station_unit(&station, total));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    pub fn finish(&mut self) {
+        self.stop_spinner();
+        if let Some(active) = self.active.take() {
+            self.collapse(&active);
+        }
+        for bar in self.bars.values() {
+            if !bar.is_finished() {
+                bar.abandon();
+            }
+        }
+        if let Some(multi) = &self.multi {
+            let _ = multi.clear();
+        }
+    }
+}
+
+fn next_steps(out: &mut dyn Write, palette: &Palette, items: &[(&str, &str)]) -> io::Result<()> {
+    let width = items
+        .iter()
+        .map(|(cmd, _)| measure_text_width(cmd))
+        .max()
+        .unwrap_or(0);
+    for (cmd, note) in items {
+        let pad = " ".repeat(width - measure_text_width(cmd) + 4);
+        writeln!(out, "  {}{pad}{}", palette.cmd(cmd), palette.dim(note))?;
+    }
+    Ok(())
+}
+
+/// The screen shown for a bare `cerul`. Until the first video is searchable it
+/// walks through setup step by step; afterwards it is a short launch pad.
+pub fn home(
+    out: &mut dyn Write,
+    palette: &Palette,
+    status: &Status,
+    models: &ModelSummary,
+) -> io::Result<()> {
+    writeln!(
+        out,
+        "{}  {}",
+        palette.bold(&format!("cerul {}", status.version)),
+        palette.dim("·  Search your videos with words")
+    )?;
+    writeln!(out)?;
+    let key_ready = models.key.available();
+    let indexed = status.episodes.len();
+    let searchable = status
+        .episodes
+        .iter()
+        .filter(|e| e.embeddings.iter().any(|x| x.complete) || !e.annotations.is_empty())
+        .count();
+    if !key_ready || searchable == 0 {
+        writeln!(out, "{}", palette.bold("Get started"))?;
+        let step = |done: bool, current: bool| {
+            if done {
+                palette.ok("✓")
+            } else if current {
+                palette.cmd("→")
+            } else {
+                palette.dim("·")
+            }
+        };
+        let rows = [
+            (
+                key_ready,
+                "Save your Gemini key",
+                "cerul auth set".to_owned(),
+                if key_ready {
+                    models.key.summary(palette)
+                } else {
+                    palette.dim("get one at https://aistudio.google.com/apikey")
+                },
+            ),
+            (
+                searchable > 0,
+                "Index a video",
+                "cerul index ./video.mp4".to_owned(),
+                if indexed > 0 && searchable == 0 {
+                    palette.warn("indexing incomplete, run it again")
+                } else {
+                    palette.dim("screen text, speech, and visual search")
+                },
+            ),
+            (
+                false,
+                "Search it",
+                "cerul search \"a person holding a cup\"".to_owned(),
+                palette.dim("or --text \"exact words\""),
+            ),
+            (
+                false,
+                "Export clips",
+                "cerul search \"...\" --save ./clips".to_owned(),
+                String::new(),
+            ),
+        ];
+        let mut current_marked = false;
+        for (number, (done, title, cmd, note)) in rows.iter().enumerate() {
+            let current = !done && !current_marked;
+            if current {
+                current_marked = true;
+            }
+            writeln!(
+                out,
+                "  {} {}. {:<22} {:<40} {}",
+                step(*done, current),
+                number + 1,
+                title,
+                palette.cmd(cmd),
+                note
+            )?;
+        }
+        writeln!(out)?;
+        if !key_ready {
+            writeln!(
+                out,
+                "{}",
+                palette.dim(
+                    "Skipping step 1 is fine: cerul index asks for the key when it first needs it."
+                )
+            )?;
+        }
+    } else {
+        let videos = match indexed {
+            1 => "1 video indexed".to_owned(),
+            n => format!("{n} videos indexed"),
+        };
+        writeln!(
+            out,
+            "Workspace  {}  ·  {videos}  ·  {}",
+            tilde(&status.workspace),
+            models.key.summary(palette)
+        )?;
+        writeln!(out)?;
+        let steps = [
+            ("cerul index ./video.mp4", "add a video"),
+            ("cerul search \"a person holding a cup\"", "find moments"),
+            (
+                "cerul search \"...\" --save ./clips",
+                "export matching clips",
+            ),
+        ];
+        next_steps(out, palette, &steps)?;
+        writeln!(out)?;
+    }
+    writeln!(
+        out,
+        "{}",
+        palette.dim("cerul status for details · cerul --help for all commands")
+    )
+}
+
+pub fn tilde(path: &Path) -> String {
+    if let Some(rest) = std::env::var_os("HOME").and_then(|home| path.strip_prefix(home).ok()) {
+        return format!("~/{}", rest.display());
+    }
+    path.display().to_string()
+}
+
+fn checks(episode: &cerul::status::EpisodeStatus, palette: &Palette) -> String {
+    let mark = |ready: bool| {
+        if ready {
+            palette.ok("✓")
+        } else {
+            palette.dim("–")
+        }
+    };
+    let has = |name: &str| episode.annotations.iter().any(|a| a == name);
+    let search = episode.embeddings.iter().any(|e| e.complete);
+    let semantic = episode
+        .annotations
+        .iter()
+        .any(|a| a.starts_with("semantic"));
+    let mut parts = vec![
+        format!("screen text {}", mark(has("screen_text"))),
+        format!("speech {}", mark(has("transcript"))),
+        format!("search {}", mark(search)),
+    ];
+    if semantic {
+        parts.push(format!("annotations {}", mark(true)));
+    }
+    if let Some(failed) = episode.embeddings.iter().find(|e| !e.complete) {
+        parts.push(palette.warn(&format!(
+            "search incomplete{}",
+            failed
+                .error
+                .as_deref()
+                .map(|e| format!(": {e}"))
+                .unwrap_or_default()
+        )));
+    }
+    if !episode.media_present {
+        parts.push(palette.warn("media missing"));
+    }
+    parts.join("   ")
+}
+
+pub fn status(
+    out: &mut dyn Write,
+    palette: &Palette,
+    status: &Status,
+    models: &ModelSummary,
+    probed: bool,
+) -> io::Result<()> {
+    writeln!(
+        out,
+        "Workspace  {}   ·   cerul {}",
+        tilde(&status.workspace),
+        status.version
+    )?;
+    writeln!(out)?;
+    writeln!(
+        out,
+        "{}",
+        palette.bold(&format!("Videos ({})", status.episodes.len()))
+    )?;
+    if status.episodes.is_empty() {
+        writeln!(
+            out,
+            "  none yet   {}",
+            palette.dim("add one with: cerul index ./video.mp4")
+        )?;
+    }
+    let width = status
+        .episodes
+        .iter()
+        .map(|e| measure_text_width(&file_name(&e.media)))
+        .max()
+        .unwrap_or(0)
+        .min(40);
+    for episode in &status.episodes {
+        let name = truncate_str(&file_name(&episode.media), 40, "…").to_string();
+        let pad = " ".repeat(width.saturating_sub(measure_text_width(&name)));
+        writeln!(out, "  {name}{pad}   {}", checks(episode, palette))?;
+    }
+    writeln!(out)?;
+    writeln!(out, "{}", palette.bold("Models"))?;
+    let dims = models
+        .embedding_dims
+        .map(|d| format!(" ({d}d)"))
+        .unwrap_or_default();
+    writeln!(
+        out,
+        "  Gemini   search {}{}   ·   speech & vision {}",
+        models.embedding, dims, models.transcription
+    )?;
+    let check = if probed {
+        let reachable = |name: &str| match status.capabilities.get(name) {
+            Some(Some(true)) => palette.ok("ok"),
+            Some(Some(false)) => palette.warn("unsupported"),
+            _ => palette.dim("not checked"),
+        };
+        format!(
+            "search {} · speech {} · vision {}",
+            reachable("embedding"),
+            reachable("transcription"),
+            reachable("vision")
+        )
+    } else {
+        palette.dim("not checked · run cerul status --providers to verify")
+    };
+    writeln!(
+        out,
+        "           {}   ·   {check}",
+        models.key.summary(palette)
+    )?;
+    for (name, provider) in &status.providers {
+        if let Some(error) = &provider.error {
+            writeln!(out, "           {} {name}: {error}", palette.warn("!"))?;
+        }
+    }
+    writeln!(out)?;
+    let ocr = match status.capabilities.get("ocr") {
+        Some(Some(true)) => "screen text OCR runs locally",
+        _ => "screen text OCR unavailable",
+    };
+    writeln!(
+        out,
+        "{}",
+        palette.dim(&format!(
+            "Storage  indexes live beside your videos (*.cerul) · {} vector space{} cached · {ocr}",
+            status.spaces.len(),
+            if status.spaces.len() == 1 { "" } else { "s" }
+        ))
+    )
+}
+
+pub fn auth(out: &mut dyn Write, palette: &Palette, key: &KeyState) -> io::Result<()> {
+    writeln!(
+        out,
+        "{}   {}",
+        palette.bold("Gemini"),
+        palette.dim(&key.endpoint)
+    )?;
+    if key.env_set {
+        writeln!(out, "  using ${} from the environment", key.env)?;
+    }
+    if key.saved {
+        writeln!(
+            out,
+            "  key saved in {}",
+            key.credentials_path
+                .as_deref()
+                .map(tilde)
+                .unwrap_or_else(|| "~/.cerul/credentials.json".into())
+        )?;
+    }
+    if !key.available() {
+        writeln!(out, "  {}", palette.warn("no key configured"))?;
+        writeln!(out)?;
+        writeln!(
+            out,
+            "Get a key at https://aistudio.google.com/apikey, then run {} or export ${}.",
+            palette.cmd("cerul auth set"),
+            key.env
+        )?;
+    } else {
+        writeln!(out)?;
+        writeln!(
+            out,
+            "{}",
+            palette
+                .dim("cerul auth set replaces the key · cerul auth remove deletes the saved one")
+        )?;
+    }
+    Ok(())
+}
+
+/// Announces what a run will do before any model request is made.
+pub fn open(
+    out: &mut dyn Write,
+    palette: &Palette,
+    media: &Path,
+    start_us: i64,
+    player: &str,
+    seeks: bool,
+    opened: bool,
+) -> io::Result<()> {
+    writeln!(
+        out,
+        "{} {} at {} with {player}",
+        if opened {
+            "▶ Opening".to_owned()
+        } else {
+            palette.bold("Dry run:") + " would open"
+        },
+        palette.bold(&file_name(media)),
+        clock(start_us)
+    )?;
+    if !seeks {
+        writeln!(
+            out,
+            "  {}",
+            palette.dim(&format!(
+                "This player starts from the beginning; the moment is at {}. Install mpv or IINA to jump straight to it.",
+                clock(start_us)
+            ))
+        )?;
+    }
+    Ok(())
+}
+
+pub fn index_plan(
+    out: &mut dyn Write,
+    palette: &Palette,
+    paths: &[PathBuf],
+    no_ocr: bool,
+    no_audio: bool,
+) -> io::Result<()> {
+    let names: Vec<String> = paths.iter().map(|path| file_name(path)).collect();
+    writeln!(
+        out,
+        "{} {}",
+        palette.bold("Indexing"),
+        truncate_str(&names.join(", "), 60, "…")
+    )?;
+    let mut stations = Vec::new();
+    if !no_ocr {
+        stations.push(format!("screen text {}", palette.dim("(local)")));
+    }
+    if !no_audio {
+        stations.push(format!("speech {}", palette.dim("(Gemini)")));
+    }
+    stations.push(format!("search index {}", palette.dim("(Gemini)")));
+    writeln!(out, "  {}", stations.join(&palette.dim("  ·  ")))?;
+    writeln!(out)
+}
+
+pub fn index(
+    out: &mut dyn Write,
+    palette: &Palette,
+    report: &index::pipeline::Report,
+    names: &BTreeMap<String, PathBuf>,
+) -> io::Result<()> {
+    let name_of = |episode: &index::pipeline::EpisodeResult| {
+        names
+            .get(&episode.episode_id)
+            .map(|p| file_name(p))
+            .unwrap_or_else(|| {
+                episode
+                    .sidecar
+                    .file_name()
+                    .map(|n| n.to_string_lossy().trim_end_matches(".cerul").to_owned())
+                    .unwrap_or_else(|| episode.episode_id.clone())
+            })
+    };
+    if report.dry_run {
+        writeln!(out, "{} nothing was written.", palette.bold("Dry run:"))?;
+        for episode in &report.episodes {
+            writeln!(
+                out,
+                "  would index {}  {}",
+                name_of(episode),
+                palette.dim(&format!("→ {}", tilde(&episode.sidecar)))
+            )?;
+        }
+        return Ok(());
+    }
+    if report.episodes.is_empty() {
+        writeln!(out, "{} no videos were indexed.", palette.warn("!"))?;
+        return Ok(());
+    }
+    let mut ready = 0;
+    let compact = report.episodes.len() > 1
+        && report.episodes.iter().all(|e| {
+            e.streams.iter().all(|s| s.errors.is_empty()) && e.streams.iter().any(|s| s.indexed)
+        });
+    for episode in &report.episodes {
+        let name = name_of(episode);
+        let errors: Vec<&String> = episode.streams.iter().flat_map(|s| &s.errors).collect();
+        let indexed = episode.streams.iter().any(|s| s.indexed);
+        if errors.is_empty() && indexed {
+            ready += 1;
+            if compact {
+                continue;
+            }
+            writeln!(
+                out,
+                "{} {} ready to search   {}",
+                palette.ok("✓"),
+                palette.bold(&name),
+                palette.dim(&format!("index: {}", tilde(&episode.sidecar)))
+            )?;
+        } else if indexed {
+            writeln!(
+                out,
+                "{} {} partially indexed",
+                palette.warn("!"),
+                palette.bold(&name)
+            )?;
+            for error in errors {
+                writeln!(out, "    {error}")?;
+            }
+            writeln!(
+                out,
+                "    {}",
+                palette
+                    .dim("what finished is searchable now; re-run cerul index to retry the rest")
+            )?;
+        } else {
+            writeln!(out, "{} {} failed", palette.err("✗"), palette.bold(&name))?;
+            for error in errors {
+                writeln!(out, "    {error}")?;
+            }
+        }
+    }
+    if ready > 1 && ready == report.episodes.len() {
+        writeln!(
+            out,
+            "{} {} ready to search   {}",
+            palette.ok("✓"),
+            palette.bold(&format!("{ready} videos")),
+            palette.dim("indexes saved beside your videos")
+        )?;
+    }
+    if ready > 0 {
+        writeln!(out)?;
+        writeln!(out, "{}", palette.bold("Try"))?;
+        next_steps(
+            out,
+            palette,
+            &[
+                ("cerul search \"what you're looking for\"", "find moments"),
+                ("cerul search \"...\" --save ./clips", "export clips"),
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+pub struct SearchContext {
+    pub query: Option<String>,
+    pub image: Option<PathBuf>,
+    pub text: bool,
+    pub saved_to: Option<PathBuf>,
+    pub terminal: Terminal,
+    pub player: Player,
+}
+
+/// Wraps text to a column width on word boundaries.
+fn wrap(text: &str, width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if !current.is_empty()
+            && measure_text_width(&current) + 1 + measure_text_width(word) > width
+        {
+            lines.push(std::mem::take(&mut current));
+        }
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(word);
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+fn kind_label(kind: Option<Kind>) -> &'static str {
+    match kind {
+        Some(Kind::Video) => "visual",
+        Some(Kind::Speech) => "speech",
+        Some(Kind::Screen) => "screen text",
+        None => "annotation",
+    }
+}
+
+/// One card per result: title, match metadata, still frame, excerpt, and a link
+/// to the file. Modelled on the layout people already recognise from Cerul.
+pub fn search(
+    out: &mut dyn Write,
+    palette: &Palette,
+    report: &search::Report,
+    context: &SearchContext,
+) -> io::Result<()> {
+    let subject = match (&context.query, &context.image) {
+        (Some(query), _) => format!("\"{query}\""),
+        (None, Some(image)) => format!("image {}", file_name(image)),
+        (None, None) => "all indexed intervals".into(),
+    };
+    if report.dry_run {
+        writeln!(
+            out,
+            "{} search for {subject} was not run.",
+            palette.bold("Dry run:")
+        )?;
+        return Ok(());
+    }
+    if let Some(counts) = &report.counts {
+        writeln!(
+            out,
+            "{} matching interval{} across {} video{}",
+            palette.bold(&counts.records.to_string()),
+            if counts.records == 1 { "" } else { "s" },
+            counts.episodes,
+            if counts.episodes == 1 { "" } else { "s" }
+        )?;
+        return Ok(());
+    }
+    if report.hits.is_empty() {
+        writeln!(out, "No matches for {subject}.")?;
+        writeln!(out)?;
+        let mut hints = vec![("cerul status", "check which videos are indexed")];
+        if context.query.is_some() && !context.text {
+            hints.push((
+                "cerul search --text \"exact words\"",
+                "match screen text or speech exactly",
+            ));
+        }
+        if context.text {
+            hints.push((
+                "cerul search \"describe the moment\"",
+                "semantic search instead of exact text",
+            ));
+        }
+        next_steps(out, palette, &hints)?;
+        return Ok(());
+    }
+    let columns = console::Term::stdout().size().1.clamp(60, 110) as usize;
+    let body = columns.saturating_sub(12);
+    let separator = palette.dim("  ·  ");
+    writeln!(
+        out,
+        "🔍 {} for {subject}",
+        palette.bold(&format!(
+            "{} result{}",
+            report.hits.len(),
+            if report.hits.len() == 1 { "" } else { "s" }
+        ))
+    )?;
+    writeln!(out)?;
+    // One card per video: the same recording matched at several moments is one
+    // thing a person is looking at, not several unrelated results.
+    let mut groups: Vec<(String, Vec<(usize, &search::Hit)>)> = Vec::new();
+    for (index, hit) in report.hits.iter().enumerate() {
+        let key = hit
+            .media
+            .as_deref()
+            .map(|path| path.to_string_lossy().into_owned())
+            .unwrap_or_else(|| hit.episode.clone());
+        match groups.iter_mut().find(|(existing, _)| *existing == key) {
+            Some((_, moments)) => moments.push((index, hit)),
+            None => groups.push((key, vec![(index, hit)])),
+        }
+    }
+    let rule = |mark: &str| palette.dim(mark);
+    for (_, moments) in &groups {
+        let first = moments[0].1;
+        let name = first
+            .media
+            .as_deref()
+            .map(file_name)
+            .unwrap_or_else(|| first.episode.clone());
+        let title = match first.media.as_deref() {
+            Some(path) => context.terminal.file_link(&palette.bold(&name), path),
+            None => palette.bold(&name),
+        };
+        let count = if moments.len() > 1 {
+            format!(
+                "{}{}",
+                separator,
+                palette.dim(&format!("{} moments", moments.len()))
+            )
+        } else {
+            String::new()
+        };
+        writeln!(out, "  {} {title}{count}", rule("┌"))?;
+        for (index, hit) in moments {
+            writeln!(out, "  {}", rule("│"))?;
+            let mut meta = Vec::new();
+            if let Some(score) = hit.score {
+                meta.push(format!(
+                    "📊 {}",
+                    palette.ok(&format!("{:.0}% match", (score * 100.).clamp(0., 100.)))
+                ));
+            }
+            meta.push(format!(
+                "🕐 {}",
+                palette.dim(&format!("{} → {}", clock(hit.start_us), clock(hit.end_us)))
+            ));
+            meta.push(format!("🎬 {}", palette.dim(kind_label(hit.matched))));
+            writeln!(
+                out,
+                "  {}  {}  {}",
+                rule("│"),
+                palette.cmd(&format!("[{}]", index + 1)),
+                meta.join(&separator).trim_end()
+            )?;
+            if let Some(preview) = hit
+                .preview
+                .as_deref()
+                .filter(|_| context.terminal.images.is_some())
+            {
+                write!(out, "  {}       ", rule("│"))?;
+                if context.terminal.image(out, preview, 30, 8)? {
+                    writeln!(out)?;
+                }
+            }
+            let excerpt = hit.excerpt.split_whitespace().collect::<Vec<_>>().join(" ");
+            if !excerpt.is_empty() {
+                let mut lines = wrap(&excerpt, body);
+                let truncated = lines.len() > 4;
+                lines.truncate(4);
+                if truncated && let Some(last) = lines.last_mut() {
+                    last.push('…');
+                }
+                for line in lines {
+                    writeln!(
+                        out,
+                        "  {}      {}",
+                        rule("│"),
+                        palette.dim(&format!("\"{line}\""))
+                    )?;
+                }
+            }
+            if let Some(path) = hit.media.as_deref() {
+                let (label, target) = context.player.open(path, hit.start_us);
+                writeln!(
+                    out,
+                    "  {}       🔗 {}",
+                    rule("│"),
+                    context.terminal.link(&palette.cmd(&label), &target)
+                )?;
+            }
+            if let Some(clip) = hit.clip.as_deref() {
+                writeln!(
+                    out,
+                    "  {}       🎞 {}   {}",
+                    rule("│"),
+                    context.terminal.file_link(&palette.cmd("Saved clip"), clip),
+                    palette.dim(&tilde(clip))
+                )?;
+            }
+        }
+        match first.media.as_deref() {
+            Some(path) => writeln!(out, "  {} {}", rule("└"), palette.dim(&tilde(path)))?,
+            None => writeln!(out, "  {}", rule("└"))?,
+        }
+        writeln!(out)?;
+    }
+    if let Some((number, _)) = report
+        .hits
+        .iter()
+        .enumerate()
+        .find(|(_, hit)| hit.media.is_some())
+    {
+        writeln!(
+            out,
+            "{}",
+            palette.dim(&format!(
+                "Open a moment in your player: cerul open {}",
+                number + 1
+            ))
+        )?;
+        writeln!(out)?;
+    }
+    if context.terminal.images.is_none() && report.hits.iter().any(|hit| hit.preview.is_some()) {
+        writeln!(
+            out,
+            "{}",
+            palette.dim(
+                "Still frames were saved but this terminal cannot draw them; iTerm2, Ghostty, Kitty, and WezTerm can."
+            )
+        )?;
+        writeln!(out)?;
+    }
+    if report
+        .hits
+        .iter()
+        .any(|hit| matches!(hit.matched, Some(Kind::Video)))
+    {
+        writeln!(
+            out,
+            "{}",
+            palette.dim("Visual matches cover an index window (30s by default); re-index with --chunk 10s for finer moments.")
+        )?;
+        writeln!(out)?;
+    }
+    if let Some(directory) = &context.saved_to {
+        writeln!(
+            out,
+            "{} clip{} saved to {}",
+            report.hits.iter().filter(|h| h.clip.is_some()).count(),
+            if report.hits.len() == 1 { "" } else { "s" },
+            directory.display()
+        )?;
+    } else if let Some(query) = &context.query {
+        let flag = if context.text { " --text" } else { "" };
+        next_steps(
+            out,
+            palette,
+            &[(
+                &format!("cerul search{flag} \"{query}\" --save ./clips"),
+                "save these moments as clips",
+            )],
+        )?;
+    }
+    Ok(())
+}
+
+pub fn remove(
+    out: &mut dyn Write,
+    palette: &Palette,
+    report: &clean::Report,
+    names: &BTreeMap<String, PathBuf>,
+    unknown: &[PathBuf],
+) -> io::Result<()> {
+    for path in unknown {
+        writeln!(
+            out,
+            "{} {} is not indexed, so there was nothing to remove",
+            palette.dim("·"),
+            palette.bold(&file_name(path))
+        )?;
+    }
+    if report.items.is_empty() {
+        if unknown.is_empty() {
+            writeln!(
+                out,
+                "Nothing was removed.   {}",
+                palette.dim("run cerul status to see what is indexed")
+            )?;
+        }
+        return Ok(());
+    }
+    let mut lost_a_video = false;
+    for item in &report.items {
+        let subject = match item.action {
+            clean::Action::RemoveSidecar => {
+                lost_a_video = true;
+                let name = item
+                    .episode
+                    .as_ref()
+                    .and_then(|episode| names.get(episode))
+                    .map(|media| file_name(media))
+                    .unwrap_or_else(|| file_name(&item.path));
+                format!("the index for {}", palette.bold(&name))
+            }
+            clean::Action::RemoveCache => "cached previews, query vectors, and proxies".into(),
+            clean::Action::RemoveIndex => "a search index".into(),
+            clean::Action::Compact => "space inside the search indexes".into(),
+        };
+        let verb = match (report.dry_run, &item.action) {
+            (true, clean::Action::RemoveSidecar) => "would remove",
+            (false, clean::Action::RemoveSidecar) => "Removed",
+            (true, _) => "would free",
+            (false, _) => "Freed",
+        };
+        if report.dry_run {
+            writeln!(
+                out,
+                "  {} {verb} {subject}   {}",
+                palette.dim("·"),
+                palette.dim(&tilde(&item.path))
+            )?;
+        } else {
+            writeln!(out, "{} {verb} {subject}", palette.ok("✓"))?;
+        }
+    }
+    writeln!(out)?;
+    let note = match (report.dry_run, lost_a_video) {
+        (true, _) => "Dry run: nothing was changed. Video files are never touched.",
+        (false, true) => "The video files were not touched. Index them again with cerul index.",
+        (false, false) => "Nothing was lost: all of it is rebuilt on demand, with no model calls.",
+    };
+    writeln!(out, "{}", palette.dim(note))
+}
+
+pub fn annotate(
+    out: &mut dyn Write,
+    palette: &Palette,
+    report: &annotate::pipeline::Report,
+    names: &BTreeMap<String, PathBuf>,
+) -> io::Result<()> {
+    if report.dry_run {
+        writeln!(out, "{} nothing was written.", palette.bold("Dry run:"))?;
+    }
+    if report.modules.is_empty() && report.writebacks.is_empty() {
+        writeln!(out, "Nothing to annotate.")?;
+        return Ok(());
+    }
+    for module in &report.modules {
+        let name = names
+            .get(&module.episode)
+            .map(|p| file_name(p))
+            .unwrap_or_else(|| module.episode.clone());
+        let label = station_label(&module.annotation);
+        match (&module.error, module.complete) {
+            (None, true) => writeln!(
+                out,
+                "{} {}  {label}  {}",
+                palette.ok("✓"),
+                palette.bold(&name),
+                palette.dim(&format!("{} records", module.records))
+            )?,
+            (None, false) => writeln!(
+                out,
+                "{} {}  {label}  {}",
+                palette.warn("!"),
+                palette.bold(&name),
+                palette.dim(&format!("incomplete, {} records so far", module.records))
+            )?,
+            (Some(error), _) => {
+                writeln!(out, "{} {}  {label}", palette.err("✗"), palette.bold(&name))?;
+                writeln!(out, "    {error}")?;
+            }
+        }
+    }
+    for writeback in &report.writebacks {
+        match &writeback.error {
+            None => writeln!(
+                out,
+                "{} wrote LeRobot dataset {}",
+                palette.ok("✓"),
+                tilde(&writeback.destination)
+            )?,
+            Some(error) => {
+                writeln!(
+                    out,
+                    "{} LeRobot writeback failed for {}",
+                    palette.err("✗"),
+                    tilde(&writeback.source)
+                )?;
+                writeln!(out, "    {error}")?;
+            }
+        }
+    }
+    if report.partial {
+        writeln!(out)?;
+        writeln!(
+            out,
+            "{}",
+            palette.dim("Finished windows are saved; re-run the same command to resume the rest.")
+        )?;
+    }
+    Ok(())
+}
+
+/// Human error line plus a hint on how to recover.
+pub fn error(palette: &Palette, code: u8, message: &str, hint: Option<&str>) -> String {
+    let mut text = format!("{} {message}", palette.err("error:"));
+    if let Some(hint) = hint {
+        text.push_str(&format!("\n  {} {hint}", palette.dim("hint:")));
+    }
+    if code == 5 {
+        text = format!("{} {message}", palette.warn("cancelled:"));
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cerul::search::{Hit, Report};
+
+    fn hit() -> Hit {
+        Hit {
+            episode: "b52ef6450d471af5/0".into(),
+            stream: "primary".into(),
+            start_us: 12_000_000,
+            end_us: 19_500_000,
+            frame_range: None,
+            score: Some(0.7412),
+            matched: Some(Kind::Speech),
+            excerpt: "we really spent almost a year perfecting this harness".into(),
+            annotations: Vec::new(),
+            clip: None,
+            media: Some(PathBuf::from("/videos/a demo.mp4")),
+            preview: None,
+        }
+    }
+
+    #[test]
+    fn cards_name_the_file_and_stay_free_of_escapes_on_plain_terminals() {
+        let report = Report {
+            hits: vec![hit()],
+            counts: None,
+            dry_run: false,
+        };
+        let context = SearchContext {
+            query: Some("a person holding a cup".into()),
+            image: None,
+            text: false,
+            saved_to: None,
+            terminal: Terminal::none(),
+            player: Player::System,
+        };
+        let mut out = Vec::new();
+        search(&mut out, &Palette::new(false), &report, &context).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        // The episode hash and raw score never reach a person.
+        assert!(!text.contains("b52ef6450d471af5"), "{text}");
+        assert!(!text.contains("0.74"), "{text}");
+        assert!(text.contains("a demo.mp4"), "{text}");
+        assert!(text.contains("74% match"), "{text}");
+        assert!(text.contains("00:12 → 00:19"), "{text}");
+        assert!(text.contains("speech"), "{text}");
+        assert!(text.contains("perfecting this harness"), "{text}");
+        assert!(text.contains("Open video"), "{text}");
+        // No colour, hyperlink, or image control sequences without support.
+        assert!(!text.contains('\u{1b}'), "{text}");
+    }
+
+    #[test]
+    fn moments_in_one_video_share_a_card_and_keep_their_global_numbers() {
+        let mut second = hit();
+        second.start_us = 90_000_000;
+        second.end_us = 96_000_000;
+        second.score = Some(0.61);
+        second.excerpt = String::new();
+        let report = Report {
+            hits: vec![hit(), second],
+            counts: None,
+            dry_run: false,
+        };
+        let context = SearchContext {
+            query: Some("a cup".into()),
+            image: None,
+            text: false,
+            saved_to: None,
+            terminal: Terminal::none(),
+            player: Player::System,
+        };
+        let mut out = Vec::new();
+        search(&mut out, &Palette::new(false), &report, &context).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert_eq!(text.matches("a demo.mp4").count(), 2, "{text}");
+        assert!(text.contains("2 moments"), "{text}");
+        assert!(text.contains("[1]") && text.contains("[2]"), "{text}");
+        assert!(text.contains("01:30 → 01:36"), "{text}");
+        assert!(text.contains("cerul open 1"), "{text}");
+    }
+
+    #[test]
+    fn hyperlinks_percent_encode_paths_and_disappear_without_support() {
+        let terminal = Terminal {
+            hyperlinks: true,
+            images: None,
+        };
+        let link = terminal.file_link("1.mp4", Path::new("/videos/a demo.mp4"));
+        assert_eq!(
+            link,
+            "\u{1b}]8;;file:///videos/a%20demo.mp4\u{7}1.mp4\u{1b}]8;;\u{7}"
+        );
+        assert_eq!(
+            Terminal::none().file_link("1.mp4", Path::new("/videos/a demo.mp4")),
+            "1.mp4"
+        );
+        let (label, target) = Player::Iina.open(Path::new("/videos/a demo.mp4"), 12_500_000);
+        assert_eq!(label, "Open at 00:12");
+        assert_eq!(
+            target,
+            "iina://open?url=file%3A%2F%2F%2Fvideos%2Fa%2520demo.mp4&mpv_start=12.500"
+        );
+        assert_eq!(
+            Player::System.open(Path::new("/videos/a demo.mp4"), 12_500_000),
+            ("Open video".into(), "file:///videos/a%20demo.mp4".into())
+        );
+    }
+
+    #[test]
+    fn wrapping_breaks_on_words_and_keeps_every_one() {
+        let lines = wrap("the quick brown fox jumps", 11);
+        assert_eq!(lines, ["the quick", "brown fox", "jumps"]);
+        assert!(wrap("", 10).is_empty());
+    }
+}

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -35,6 +35,8 @@ pub struct Options {
     pub threshold: Option<f32>,
     pub count: bool,
     pub save: Option<PathBuf>,
+    /// Extract one still frame per hit into the workspace cache.
+    pub preview: bool,
     pub pad_us: i64,
     pub dry_run: bool,
     pub request_notice: Option<RequestNotice>,
@@ -51,6 +53,7 @@ impl Default for Options {
             threshold: None,
             count: false,
             save: None,
+            preview: false,
             pad_us: 2_000_000,
             dry_run: false,
             request_notice: None,
@@ -129,6 +132,12 @@ pub struct Hit {
     pub excerpt: String,
     pub annotations: Vec<Row>,
     pub clip: Option<PathBuf>,
+    /// Source media file for the hit's stream, when it is a video stream.
+    #[serde(default)]
+    pub media: Option<PathBuf>,
+    /// Still frame from the start of the hit, for hosts that show thumbnails.
+    #[serde(default)]
+    pub preview: Option<PathBuf>,
 }
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Counts {
@@ -187,7 +196,49 @@ fn hit(episode: &str, stream: &str, range: TimeRange, rows: &[Row]) -> Hit {
         excerpt: String::new(),
         annotations: annotations(rows, episode, stream, range),
         clip: None,
+        media: None,
+        preview: None,
     }
+}
+/// Ranked windows stay separate moments unless they cover mostly the same time;
+/// the small overlap between neighbouring index windows must not chain a whole
+/// video into one hit.
+fn mostly_same(previous: &Hit, next: &Hit) -> bool {
+    let overlap = previous.end_us.min(next.end_us) - next.start_us;
+    let shortest = (previous.end_us - previous.start_us).min(next.end_us - next.start_us);
+    shortest <= 0 || overlap * 2 >= shortest
+}
+/// One still frame at the start of a hit, cached under the workspace so repeated
+/// searches reuse it and `clean --cache` removes it.
+fn preview(
+    found: &Hit,
+    episodes: &BTreeMap<String, Episode>,
+    directory: &Path,
+) -> Result<Option<PathBuf>> {
+    let episode = episodes.get(&found.episode).context("unknown episode")?;
+    let Stream::Video { path, .. } = episode.video(&found.stream)? else {
+        return Ok(None);
+    };
+    let source = episode.source.root.join(path);
+    let key = storage::cache_key(&(&found.episode, &found.stream, found.start_us, "preview"))?;
+    let destination = directory.join(format!("{key}.png"));
+    if destination.is_file() {
+        return Ok(Some(destination));
+    }
+    let coverage = episode
+        .video_coverage(&found.stream)?
+        .context("hit stream has no episode coverage")?;
+    let start = found.start_us.clamp(coverage.start_us, coverage.end_us);
+    fs::create_dir_all(directory)?;
+    // PNG at thumbnail width keeps inline terminal rendering fast and is readable
+    // by every terminal graphics protocol.
+    media::extract::still(
+        &source,
+        episode.episode_to_source(&found.stream, start)?,
+        &destination,
+        480,
+    )?;
+    Ok(Some(destination))
 }
 fn merge_hits(mut hits: Vec<Hit>, vector: bool) -> Vec<Hit> {
     hits.sort_by(|a, b| {
@@ -200,6 +251,7 @@ fn merge_hits(mut hits: Vec<Hit>, vector: bool) -> Vec<Hit> {
             && previous.episode == next.episode
             && previous.stream == next.stream
             && next.start_us <= previous.end_us
+            && (!vector || mostly_same(previous, &next))
         {
             previous.end_us = previous.end_us.max(next.end_us);
             if next.score > previous.score {
@@ -266,7 +318,7 @@ async fn run_inner(
             dry_run: true,
         });
     }
-    if options.save.is_some() {
+    if options.save.is_some() || options.preview {
         media::check_dependencies().map_err(|error| unavailable(error.to_string()))?;
     }
     let vector = !options.text && (options.query.is_some() || options.image.is_some());
@@ -413,7 +465,7 @@ async fn run_inner(
                     Provider::from_env(config.embedding.clone(), 1, None, cancel.clone())?;
                 provider.request_notice = options.request_notice.clone();
                 probes::check(&provider, probes::Capability::Embedding, workspace, false).await?;
-                let input = if let Some(path) = &options.image {
+                let (identity, input) = if let Some(path) = &options.image {
                     let bytes = fs::read(path)?;
                     let mime = match image::guess_format(&bytes)? {
                         image::ImageFormat::Png => "image/png",
@@ -421,11 +473,36 @@ async fn run_inner(
                         image::ImageFormat::WebP => "image/webp",
                         _ => return Err(unavailable("query image must be PNG, JPEG, or WebP")),
                     };
-                    Input::Image(bytes, mime.into())
+                    use sha2::Digest;
+                    let digest = format!("{:x}", sha2::Sha256::digest(&bytes));
+                    (digest, Input::Image(bytes, mime.into()))
                 } else {
-                    Input::Text(options.query.clone().unwrap())
+                    let text = options.query.clone().unwrap();
+                    (text.clone(), Input::Text(text))
                 };
-                let query = provider.embed(input, true).await?;
+                // The same question in the same space always embeds the same way,
+                // so repeated and refined searches need no further model calls.
+                let cached = workspace.join("cache").join("queries").join(format!(
+                    "{}.json",
+                    storage::cache_key(&(&space, &identity))?
+                ));
+                let query = match fs::read(&cached)
+                    .ok()
+                    .and_then(|bytes| serde_json::from_slice::<Vec<f32>>(&bytes).ok())
+                    .filter(|vector| vector.len() == dims)
+                {
+                    Some(vector) => vector,
+                    None => {
+                        let vector = provider.embed(input, true).await?;
+                        // A cache write must never fail the search that produced it.
+                        if fs::create_dir_all(cached.parent().expect("cache path has a parent"))
+                            .is_ok()
+                        {
+                            let _ = storage::write_json(&cached, &vector);
+                        }
+                        vector
+                    }
+                };
                 let total = index.count().await?;
                 let mut budget = options.limit.saturating_mul(3).max(32).min(total);
                 loop {
@@ -558,6 +635,24 @@ async fn run_inner(
     }
     let mut hits = merge_hits(hits, vector);
     hits.truncate(options.limit);
+    for found in &mut hits {
+        if let Some(Stream::Video { path, .. }) = episodes
+            .get(&found.episode)
+            .and_then(|episode| episode.video(&found.stream).ok())
+        {
+            found.media = Some(episodes[&found.episode].source.root.join(path));
+        }
+    }
+    if options.preview {
+        let directory = workspace.join("cache").join("previews");
+        for found in &mut hits {
+            cancelled(&cancel)?;
+            // A missing preview must never fail a search; it is decoration.
+            if let Ok(Some(frame)) = preview(found, &episodes, &directory) {
+                found.preview = Some(frame);
+            }
+        }
+    }
     if let Some(directory) = &options.save {
         for found in &mut hits {
             cancelled(&cancel)?;

--- a/src/status.rs
+++ b/src/status.rs
@@ -220,6 +220,18 @@ pub fn inspect(workspace: &Path, path: Option<&Path>) -> Result<Status> {
     })
 }
 
+/// Perception belongs to a later milestone, so its default endpoint is not a
+/// service anyone can reach. Probing it would contact Cerul's servers on a plain
+/// status check and report the resulting authentication failure as if the person
+/// had misconfigured something. Only an endpoint someone actually pointed
+/// elsewhere, or gave a key for, is theirs to check.
+fn perception_configured(config: &crate::config::Config) -> bool {
+    let default = crate::config::Config::default();
+    config.perception.base_url.trim_end_matches('/')
+        != default.perception.base_url.trim_end_matches('/')
+        || std::env::var(&config.perception.api_key_env).is_ok_and(|key| !key.trim().is_empty())
+}
+
 /// Explicit remote inspection. A failure does not suppress results for other endpoints.
 pub async fn check_providers(
     status: &mut Status,
@@ -244,7 +256,7 @@ pub async fn check_providers(
         dims: None,
     };
     let mut partial = false;
-    for (name, endpoint, capability) in [
+    let mut endpoints = vec![
         ("embedding", &config.embedding, Capability::Embedding),
         ("vision", &config.vision, Capability::Vision),
         (
@@ -252,8 +264,11 @@ pub async fn check_providers(
             &config.transcription,
             Capability::Transcription,
         ),
-        ("perception", &perception, Capability::Perception),
-    ] {
+    ];
+    if perception_configured(config) {
+        endpoints.push(("perception", &perception, Capability::Perception));
+    }
+    for (name, endpoint, capability) in endpoints {
         let mut result = ProviderStatus {
             base_url: endpoint.base_url.clone(),
             model: (name != "perception").then(|| endpoint.model.clone()),
@@ -370,6 +385,16 @@ mod tests {
         let local = inspect(dir.path(), None).unwrap();
         assert!(local.providers.is_empty());
         assert_eq!(local.capabilities["perception"], None);
+    }
+    #[test]
+    fn unreleased_perception_endpoint_is_not_contacted_by_default() {
+        let mut config = crate::config::Config::default();
+        assert!(
+            !perception_configured(&config),
+            "a plain status check must not reach Cerul's own servers"
+        );
+        config.perception.base_url = "http://127.0.0.1:9/".into();
+        assert!(perception_configured(&config));
     }
     #[test]
     fn fresh_status_does_not_create_workspace_or_assume_remote_capabilities() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -97,7 +97,7 @@ fn offline_index_exits_partial_with_ndjson_events_and_endpoint_notice_once() {
             .iter()
             .filter(|e| e["msg"]
                 .as_str()
-                .is_some_and(|s| s.starts_with("Sending model requests")))
+                .is_some_and(|s| s.starts_with("Using Gemini")))
             .count(),
         1
     );
@@ -109,7 +109,7 @@ fn offline_index_exits_partial_with_ndjson_events_and_endpoint_notice_once() {
 }
 
 #[test]
-fn clean_dry_run_and_explicit_execution_keep_authoritative_sidecars() {
+fn removal_dry_run_and_explicit_execution_keep_authoritative_sidecars() {
     let dir = tempfile::tempdir().unwrap();
     let cache = dir.path().join(".cerul/cache");
     let sidecar = dir.path().join(".cerul/sidecars/keep");
@@ -117,18 +117,20 @@ fn clean_dry_run_and_explicit_execution_keep_authoritative_sidecars() {
     std::fs::create_dir_all(&sidecar).unwrap();
     std::fs::write(cache.join("proxy.mp4"), b"cache").unwrap();
     std::fs::write(sidecar.join("transcript.jsonl"), b"annotation").unwrap();
-    let output = cli(dir.path(), &["--json", "clean", "--cache", "--dry-run"]);
+    let output = cli(dir.path(), &["--json", "remove", "--cache", "--dry-run"]);
     assert!(output.status.success());
     assert_eq!(final_json(&output)["items"][0]["action"], "remove_cache");
     assert!(cache.exists());
-    let output = cli(dir.path(), &["--json", "clean", "--cache"]);
+    let output = cli(dir.path(), &["--json", "remove", "--cache"]);
     assert!(output.status.success());
     assert_eq!(final_json(&output)["dry_run"], false);
     assert!(!cache.exists());
     assert!(sidecar.join("transcript.jsonl").exists());
-    let rejected = cli(dir.path(), &["--json", "clean", "--sidecars", "."]);
-    assert_eq!(rejected.status.code(), Some(2));
-    assert!(sidecar.exists());
+    // Sidecars the registry does not know about are never touched, and asking to
+    // forget a path with no registered episodes is a no-op rather than a failure.
+    let untouched = cli(dir.path(), &["--json", "remove", ".", "--yes"]);
+    assert!(untouched.status.success());
+    assert!(sidecar.join("transcript.jsonl").exists());
 }
 
 #[test]
@@ -231,6 +233,9 @@ fn ctrl_c_stops_media_subprocess_and_exits_cancelled() {
         time::{Duration, Instant},
     };
     let dir = tempfile::tempdir().unwrap();
+    // The stub ffprobe below stands in for real inspection, so the input only
+    // has to exist for the CLI to reach it.
+    fs::write(dir.path().join("sample.mp4"), b"").unwrap();
     let bin = dir.path().join("bin");
     fs::create_dir(&bin).unwrap();
     let marker = dir.path().join("media-started");
@@ -421,4 +426,175 @@ fn missing_key_keeps_local_processing_and_environment_bypasses_corrupt_saved_key
         .unwrap();
     assert_eq!(output.status.code(), Some(6), "{:?}", output);
     assert!(!String::from_utf8_lossy(&output.stdout).contains("credential file"));
+}
+
+#[test]
+fn human_mode_renders_text_and_json_mode_stays_machine_readable() {
+    let dir = tempfile::tempdir().unwrap();
+    // A bare invocation is the start page, not a JSON dump.
+    let home = cli(dir.path(), &[]);
+    assert!(home.status.success());
+    let text = String::from_utf8_lossy(&home.stdout);
+    assert!(text.starts_with("cerul 0."), "{text}");
+    assert!(text.contains("Get started"), "{text}");
+    assert!(text.contains("cerul auth set"), "{text}");
+    assert!(text.contains("cerul index ./video.mp4"), "{text}");
+    assert!(text.contains("cerul auth set"), "{text}");
+    assert!(serde_json::from_str::<Value>(&text).is_err());
+    assert!(home.stderr.is_empty());
+
+    let status = cli(dir.path(), &["status"]);
+    assert!(status.status.success());
+    let text = String::from_utf8_lossy(&status.stdout);
+    assert!(text.contains("Videos (0)"), "{text}");
+    assert!(text.contains("key not set"), "{text}");
+    assert!(text.contains("not checked"), "{text}");
+
+    let auth = cli(dir.path(), &["auth"]);
+    assert!(auth.status.success());
+    assert!(String::from_utf8_lossy(&auth.stdout).contains("no key configured"));
+    let auth_json = cli(dir.path(), &["--json", "auth"]);
+    let value = final_json(&auth_json);
+    assert_eq!(value["saved"], false);
+    assert_eq!(value["env"], "GEMINI_API_KEY");
+    // Saving a key needs a person at a terminal; scripts get a clear failure.
+    let set = cli(dir.path(), &["auth", "set"]);
+    assert_eq!(set.status.code(), Some(2));
+    assert!(set.stdout.is_empty());
+    let text = String::from_utf8_lossy(&set.stderr);
+    assert!(text.starts_with("error:"), "{text}");
+    assert!(text.contains("GEMINI_API_KEY"), "{text}");
+    let removed = cli(dir.path(), &["auth", "remove"]);
+    assert!(removed.status.success());
+    assert!(String::from_utf8_lossy(&removed.stdout).contains("No saved Gemini key"));
+
+    // Failures go to stderr with a hint; stdout stays empty for people too.
+    let missing = cli(dir.path(), &["index", "missing.mp4"]);
+    assert_eq!(missing.status.code(), Some(2));
+    assert!(missing.stdout.is_empty());
+    let text = String::from_utf8_lossy(&missing.stderr);
+    assert!(text.starts_with("error:"), "{text}");
+    assert!(
+        text.contains("no such file or directory: missing.mp4"),
+        "{text}"
+    );
+    assert!(text.contains("hint:"), "{text}");
+
+    // A refusal for a missing selection names a command that works.
+    let empty = cli(dir.path(), &["remove"]);
+    assert_eq!(empty.status.code(), Some(2));
+    let text = String::from_utf8_lossy(&empty.stderr);
+    assert!(text.contains("hint: cerul remove ./video.mp4"), "{text}");
+
+    // Argument errors keep clap's own formatting and exit code.
+    let bad = cli(dir.path(), &["search", "--limit", "many"]);
+    assert_eq!(bad.status.code(), Some(2));
+    assert!(bad.stdout.is_empty());
+
+    let search = cli(dir.path(), &["search", "--text", "nothing"]);
+    assert!(search.status.success());
+    let text = String::from_utf8_lossy(&search.stdout);
+    assert!(text.contains("No matches for \"nothing\""), "{text}");
+    assert!(text.contains("cerul status"), "{text}");
+
+    let quiet = cli(dir.path(), &["--quiet", "status"]);
+    assert!(quiet.status.success());
+    assert!(quiet.stdout.is_empty());
+}
+
+#[test]
+fn unquoted_multi_word_query_gets_a_quoting_hint() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = cli(dir.path(), &["search", "one", "people"]);
+    assert_eq!(output.status.code(), Some(2));
+    let text = String::from_utf8_lossy(&output.stderr);
+    assert!(text.contains("cerul search \"one people\""), "{text}");
+    let json = cli(dir.path(), &["--json", "search", "one", "people"]);
+    assert_eq!(final_json(&json)["error"]["code"], "invalid_configuration");
+}
+
+#[test]
+fn open_needs_a_recent_search_and_reports_what_it_would_play() {
+    let dir = tempfile::tempdir().unwrap();
+    let cold = cli(dir.path(), &["open"]);
+    assert_eq!(cold.status.code(), Some(2));
+    let text = String::from_utf8_lossy(&cold.stderr);
+    assert!(text.contains("no recent search"), "{text}");
+
+    let media = dir.path().join("demo.mp4");
+    std::fs::write(&media, b"").unwrap();
+    let cache = dir.path().join(".cerul").join("cache");
+    std::fs::create_dir_all(&cache).unwrap();
+    std::fs::write(
+        cache.join("last-search.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "query": "a cup",
+            "hits": [{"media": media, "start_us": 12_000_000i64, "end_us": 19_000_000i64}]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let opened = cli(dir.path(), &["--json", "open", "1", "--dry-run"]);
+    let value = final_json(&opened);
+    assert_eq!(value["opened"], false);
+    assert_eq!(value["start_us"], 12_000_000i64);
+    let human = cli(dir.path(), &["open", "--dry-run"]);
+    assert!(human.status.success());
+    assert!(
+        String::from_utf8_lossy(&human.stdout).contains("would open demo.mp4 at 00:12"),
+        "{}",
+        String::from_utf8_lossy(&human.stdout)
+    );
+    // Numbers outside the last search are refused, not silently clamped.
+    let missing = cli(dir.path(), &["open", "3"]);
+    assert_eq!(missing.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&missing.stderr).contains("returned 1 result"),
+        "{}",
+        String::from_utf8_lossy(&missing.stderr)
+    );
+}
+
+#[test]
+fn completions_are_printed_verbatim_and_removal_of_an_unindexed_video_is_a_no_op() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = cli(dir.path(), &["completions", "zsh"]);
+    assert!(script.status.success());
+    let text = String::from_utf8_lossy(&script.stdout);
+    assert!(
+        text.starts_with("#compdef cerul"),
+        "{}",
+        &text[..40.min(text.len())]
+    );
+    assert!(
+        text.contains("index"),
+        "the script must cover the subcommands"
+    );
+    assert!(script.stderr.is_empty());
+    for shell in ["bash", "fish", "powershell", "elvish"] {
+        assert!(cli(dir.path(), &["completions", shell]).status.success());
+    }
+    assert_eq!(
+        cli(dir.path(), &["completions", "tcsh"]).status.code(),
+        Some(2)
+    );
+
+    // Removing a video that was never indexed says so instead of failing.
+    let media = dir.path().join("demo.mp4");
+    std::fs::write(&media, b"").unwrap();
+    let quiet = cli(dir.path(), &["remove", media.to_str().unwrap(), "--yes"]);
+    assert!(quiet.status.success());
+    assert!(
+        String::from_utf8_lossy(&quiet.stdout).contains("is not indexed"),
+        "{}",
+        String::from_utf8_lossy(&quiet.stdout)
+    );
+    // A path that does not exist is still an error, before anything is planned.
+    let missing = cli(dir.path(), &["remove", "absent.mp4", "--yes"]);
+    assert_eq!(missing.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&missing.stderr).contains("no such file or directory"),
+        "{}",
+        String::from_utf8_lossy(&missing.stderr)
+    );
 }


### PR DESCRIPTION
## What this changes

Without `--json` the CLI printed the same JSON it hands to agents. A person running `cerul` saw episode hashes, raw station names like `screen_text`, and one progress line per frame. This adds a rendering layer so the terminal output is written for people, while `--json` keeps its existing protocol byte for byte.

Rendering lives in the binary only (`src/render.rs`). The library still emits structured values and never touches a terminal, per the constraint in DESIGN.md.

### Before

```
(base) jessytsui@192 video % cerul
{
  "capabilities": { "embedding": null, "ocr": true, ... },
  "episodes": [],
  "workspace": "/Users/jessytsui/.cerul"
}
(base) jessytsui@192 video % cerul index ./1.mp4
b52ef6450d471af5/0 screen_text: 1/35
b52ef6450d471af5/0 screen_text: 2/35
... 33 more lines ...
```

### After

```
cerul 0.0.4  ·  Search your videos with words

Get started
  → 1. Save your Gemini key   cerul auth set              get one at https://aistudio.google.com/apikey
  · 2. Index a video          cerul index ./video.mp4     screen text, speech, and visual search
  · 3. Search it              cerul search "a cup"        or --text "exact words"
  · 4. Export clips           cerul search "..." --save ./clips
```

```
🔍 3 results for "computer vision"

  ┌ 1.mp4  ·  3 moments
  │
  │  [1]  📊 53% match  ·  🕐 00:00 → 00:30  ·  🎬 visual
  │       🔗 Open at 00:00
  │
  │  [2]  📊 52% match  ·  🕐 00:50 → 01:09  ·  🎬 visual
  │       🔗 Open at 00:50
  └ ~/sample/video/1.mp4
```

## Command surface

Seven visible commands. `open`, `auth`, and `remove` are new; `remove` absorbs what `clean` did, so `clean` is gone as a separate command.

| Command | Purpose |
| --- | --- |
| `index` | index videos |
| `search` | find moments |
| `status` | what is indexed, which models, storage |
| `open [N]` | play result N at its moment |
| `auth [set\|remove]` | manage the saved Gemini key |
| `annotate` | semantic annotations |
| `remove [paths] [--cache] [--all-indexes]` | forget videos, or free regenerable disk |

`completions <shell>` exists but is hidden from the list: it is run once when setting up a shell.

Removal asks before losing a video and never asks for the regenerable flags, so consequence is visible at the point of action rather than encoded in a command name. Non-terminal callers must pass `--yes`.

## Two fixes found while testing this

**Search felt slow.** Local work takes 0.05s; the wait was one Gemini round trip, measured between 1.2s and 8.7s. Query embeddings are now cached by embedding space and query, and stills use ffmpeg input seeking instead of probing every frame timestamp.

| | Before | After |
| --- | --- | --- |
| Repeat the same search | 1.2–8.7s | 0.16s |
| Three preview frames | 2.1s | 0.4s |

The still extraction cost no longer grows with recording length, which mattered more than the ratio: probing frame timestamps took 1.76s on a one-minute clip.

**`status --providers` contacted Cerul's own servers.** The perception endpoint defaults to `https://api.cerul.ai`, which is a later milestone and not a running service. A plain status check requested it and reported the 401 as though the person had misconfigured something. It is now probed only when someone points it elsewhere or sets its key variable; until then its capability stays `null` and no request leaves the machine for it. DESIGN.md already required that perception not be advertised as available.

## Library changes

Kept minimal and additive, so `--json` consumers are unaffected:

- `search::Hit` gains `media` and `preview` paths; `search::Options` gains `preview`.
- `media::extract::still()` for fast single-frame extraction.
- Ranked vector hits merge only when their windows mostly coincide. Previously the 5s overlap between neighbouring 30s index windows chained a whole video into one hit.
- Schema renamed `clean-result.json` → `remove-result.json` to match the command.

## Verification

Ran the full CI chain locally on macOS with ffmpeg 8.1:

| Check | Result |
| --- | --- |
| `cargo fmt --check` | pass |
| `cargo clippy --all-targets --locked -- -D warnings` | pass, no warnings |
| `cargo test --locked` | 101 passed, 0 failed |
| `cargo run --locked --example generate_schemas -- --check` | pass |
| `cargo package --locked` | pass |
| `cargo build --release --locked` | pass |

Not run locally: the Linux-only LeRobot loader round-trip, which needs the pinned torch and lerobot wheels. CI covers it.

Tests added cover the start page in both states, the search card layout and result grouping, hyperlink percent-encoding, text wrapping, `open`'s three error paths, completion generation for five shells, removal of an unindexed video, and that the default configuration never contacts the perception endpoint. A guard asserts that plain terminals receive no escape sequences at all.

Also verified by hand: indexing two videos through a pseudo-terminal to confirm progress collapsing and line endings, both terminal image protocols emitting correctly, and that removing a video leaves it out of both `status` and subsequent searches while the file itself is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)