### PR TITLE
Prepare the 0.0.5 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "cerul"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerul"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2024"
 license = "Apache-2.0"
 description = "Searchable video and annotation data, using your own model endpoints"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,7 +22,7 @@ cerul search "A person puts a cup on the table" --save ./clips
 On first use, enter your [Gemini API key](https://aistudio.google.com/apikey)
 when prompted. Model processing sends inputs to Gemini and may incur API charges.
 
-You can also download an archive from [GitHub Releases](https://github.com/cerul-ai/cerul/releases/tag/v0.0.4).
+You can also download an archive from [GitHub Releases](https://github.com/cerul-ai/cerul/releases/tag/v0.0.5).
 Keep `cerul`, `cerul-ffmpeg`, and `cerul-ffprobe` together when moving them.
 
 ## Build from source (developers)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,6 +1,6 @@
 # Release artifacts
 
-The v0.0.4 rewrite is not published by building or reviewing this branch.
+Building or reviewing a branch never publishes a release.
 Package publishing is a separate release operation after M1 acceptance.
 Existing tags and `ffmpeg-vendor-*` assets must be preserved for downstream compatibility.
 
@@ -10,20 +10,21 @@ The first release uses GitHub Releases and the website installer redirect.
 npm and Homebrew publishing can follow separately.
 
 1. Verify PR checks and acceptance results, then merge the release PR into `main`.
-2. From the merged `main`, confirm Cargo.toml and packaging/dist.toml both use
-   `0.0.4`, then create and push the version tag:
+2. From the merged `main`, confirm Cargo.toml and packaging/dist.toml agree on
+   the version being released, then create and push the matching tag. The
+   commands below use `0.0.5`; substitute the version in the manifests.
 
    ```sh
    git switch main
    git pull --ff-only origin main
-   git tag -a v0.0.4 -m "Release Cerul 0.0.4"
-   git push origin v0.0.4
+   git tag -a v0.0.5 -m "Release Cerul 0.0.5"
+   git push origin v0.0.5
    ```
 
 3. Wait for the Release workflow to publish both platform archives, the shell
    installer, checksums, and corresponding media sources to GitHub Releases.
 4. Configure `https://cerul.ai/install.sh` to redirect temporarily (HTTP 302 or 307)
-   to `https://github.com/cerul-ai/cerul/releases/download/v0.0.4/cerul-installer.sh`.
+   to `https://github.com/cerul-ai/cerul/releases/download/v0.0.5/cerul-installer.sh`.
    Use short caching so the target can be updated for future releases. Verify
    that following the redirect returns the shell script, not an HTML page.
 5. On each supported platform, install from the public README command and verify
@@ -75,7 +76,7 @@ written under `target/distrib/`, including:
 - `cerul-<target>.tar.xz` and SHA-256 files.
 - `cerul-installer.sh`.
 - `cerul.rb`, a Homebrew formula.
-- `cerul-npm-package.tar.gz`, the `cerul` 0.0.4 npm wrapper.
+- `cerul-npm-package.tar.gz`, the `cerul` npm wrapper at the manifest version.
 - A source archive and aggregate checksums.
 
 The source archive uses committed Git content. Regenerate it after committing;

--- a/packaging/dist.toml
+++ b/packaging/dist.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerul"
-version = "0.0.4"
+version = "0.0.5"
 description = "Searchable video and annotation data, using your own model endpoints"
 license = "Apache-2.0 AND GPL-2.0-or-later AND Zlib"
 homepage = "https://cerul.ai"


### PR DESCRIPTION
Bumps the manifests to 0.0.5 and updates the version references that a release touches.

- `Cargo.toml`, `Cargo.lock`, `packaging/dist.toml` → 0.0.5
- `docs/installation.md`: the GitHub Releases download link points at the new tag
- `docs/releases.md`: the tag commands and the `cerul.ai/install.sh` redirect target point at v0.0.5

Two lines that restated the version now refer to the manifests instead, so the tag-command instruction and the npm wrapper description will not go stale at 0.0.6.

Contents of the release: the CLI presentation layer from #249, plus the query-embedding cache, fast still extraction, and the fix that stopped `status --providers` from contacting the unreleased perception endpoint.

## Verification

`cargo build --release --locked` passes and the binary reports `cerul 0.0.5`. No `0.0.4` references remain outside historical notes in DESIGN.md about the 0.0.2 npm package and the v0.0.3 milestone target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)