### PR TITLE
Align documentation with the relaunched CLI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,9 +17,9 @@ body:
       label: Steps to Reproduce
       description: List the minimal steps needed to reproduce the issue.
       placeholder: |
-        1. Go to ...
-        2. Call ...
-        3. Observe ...
+        1. Run `cerul ...` with these options: ...
+        2. Use this input format or a small reproducible fixture: ...
+        3. Observe this output or exit code: ...
     validations:
       required: true
   - type: textarea
@@ -35,12 +35,19 @@ body:
     validations:
       required: true
   - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include `cerul --version`, operating system and CPU architecture, and installation method. For provider issues, include the provider kind and model name without credentials.
+    validations:
+      required: true
+  - type: textarea
     id: scope
     attributes:
       label: Affected Area
-      description: Which directory, module, route, or worker is affected?
+      description: Which command or core module is affected (for example indexing, search, OCR, model endpoints, or LeRobot writeback)?
   - type: textarea
     id: notes
     attributes:
       label: Extra Context
-      description: Logs, screenshots, payloads, or anything else helpful.
+      description: Relevant logs or output, with API keys, private paths, and user media removed.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -27,4 +27,4 @@ body:
     id: scope
     attributes:
       label: Scope Notes
-      description: Mention affected areas such as `apps/cli`, `integrations/mcp`, or `docs`.
+      description: Mention affected commands or areas such as `src/index`, `src/search`, `src/annotate`, `src/lerobot`, or `docs`. This repository owns the video processing core and CLI; product UI and hosted services are outside its scope.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,8 +14,9 @@ published. The workspace admits one writer at a time.
 This crate exposes local processing and endpoint clients. It does not implement
 a product UI, hosted inference, or HTTP/MCP serving.
 
-Rust types produce public schemas. Legacy platform OpenAPI projections are
-retired rather than hand-modified into a second contract.
+Rust types produce the public schemas in `schemas/`. Regenerate them with
+`cargo run --locked --example generate_schemas`; add `-- --check` to verify
+that committed schemas match the types.
 
 LanceDB 0.38.0 currently needs its `remote` Cargo feature to compile: its job
 error conversion references a feature-gated HTTP error type. Cerul nevertheless

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,13 @@ Run `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, a
 OCR, model adapters, or dataset writers. Never commit credentials or user data.
 Fixtures and embedded models require clear provenance and compatible licenses.
 
-Live default-provider checks run on this repository's `main` branch, never on
-pull requests or fork code. Maintainers configure the `GEMINI_API_KEY` Actions secret for this workflow;
-a missing credential fails the live check rather than silently passing.
-To run the same checks locally, configure the key in your environment and run
-`cargo run --locked --example verify_gemini`. This sends only synthetic probe
+Core CI runs offline checks on Linux and macOS, including generated-schema and
+source-package checks. Linux also runs official LeRobot loader round-trips.
+Live provider checks are a maintainer release check, run locally with your own
+`GEMINI_API_KEY` using `cargo run --locked --example verify_gemini`.
+The release workflow does not require a model credential. See the
+[release checklist](docs/releases.md) for the full publication process.
+The local provider check sends only synthetic probe
 inputs: text, a small image, a two-second video, and silence. It checks endpoint
 capabilities and response shapes, not retrieval quality or speech timestamp
 accuracy; the remaining DESIGN.md acceptance checks are still required.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -23,8 +23,8 @@ Public design reference for the local video processing core.
 | Language | Annotation text fields are English. |
 | LeRobot | Read v3.0 and v3.1 and produce sidecars. Writeback accepts only an existing compatible v3.1 dataset and writes subtask language entries. v3.0 writeback is unsupported; Cerul does not upgrade formats. Events and flags remain in sidecars. |
 | Platforms | M1: macOS arm64 and Linux x86_64. Windows is M2. |
-| Versions | Increment `v0.0.x` without alpha/beta suffixes. The old npm package reached 0.0.2; the first rewritten release is **v0.0.3**, with the same version on crates.io. Milestones M1/M2/M3 are not fixed version numbers. |
-| Distribution | cargo-dist shell installer, Homebrew formula, and npm `cerul` wrapper. |
+| Versions | Increment `v0.0.x` without alpha/beta suffixes. Cargo.toml, packaging/dist.toml, and release tags must agree. Milestones M1/M2/M3 are not fixed version numbers. |
+| Distribution | GitHub Releases with a cargo-dist shell installer. Homebrew formula and npm wrapper artifacts are generated; registry/tap publication is separate. See [release artifacts](docs/releases.md). |
 | Telemetry | None. |
 | Scope | M1 is a complete video retrieval and semantic annotation CLI requiring only third-party model credentials. `status --providers` probes only the endpoints M1 uses; the later-milestone perception endpoint is contacted solely when configured explicitly. Pose, depth, and segmentation depend on later perception services and must not be advertised as available. |
 
@@ -126,10 +126,10 @@ Each subtype is a module: frames → timestamped contact sheet → schema-constr
 | `--count` | Filters only: return exact-label record and episode counts. No natural-language probe counting. |
 | `--save DIR`, `--pad 2s` | Save matched MP4 clips. |
 | `--preview`, `--no-preview` | Cache one still frame per hit under workspace `cache/previews/` and expose it as `preview`. Stills use input seeking, so their cost does not grow with recording length. Default: on when the terminal can draw images. |
-
-Query embeddings are cached under workspace `cache/queries/` keyed by embedding space and query, so repeating or refining a search needs no further model call. Both caches are disposable and freed by `remove --cache`.
 | `--rerank` | M2: vision reranking of the first 20 candidates. |
 | `--text` | Substring match over transcript and screen text without vectors. |
+
+Query embeddings are cached under workspace `cache/queries/` keyed by embedding space and query, so repeating a query in the same space needs no further model call. Both caches are disposable and freed by `remove --cache`.
 
 Results: `hits[]` containing episode, stream, start_us, end_us, optional frame_range, score, matched (video/speech/screen), excerpt, and annotations.
 
@@ -137,7 +137,7 @@ Results: `hits[]` containing episode, stream, start_us, end_us, optional frame_r
 
 Return a workspace overview or an episode's annotation inventory. Running `cerul` without a command is equivalent to status.
 
-Ordinary status does not probe remote endpoints; remote capabilities are null (unknown). `--providers` probes all four endpoints, caching successful checks for seven days. `--recompute` refreshes checks; `--dry-run` performs none. Explicit probes report endpoint, model, check time, and error. Unsupported is false; missing keys and network errors remain null. Preserve other endpoint results when one fails and return exit code 6. The JSON root contains `capabilities`. Perception's advertised tasks do not imply that M1 implements grounding/world.
+Ordinary status does not probe remote endpoints; remote capabilities are null (unknown). `--providers` probes embedding, vision, and transcription, plus perception only when explicitly configured, caching successful checks for seven days. `--recompute` refreshes checks; `--dry-run` performs none. Explicit probes report endpoint, model, check time, and error. Unsupported is false; missing keys and network errors remain null. Preserve other endpoint results when one fails and return exit code 6. The JSON root contains `capabilities`. Perception's advertised tasks do not imply that M1 implements grounding/world.
 
 ## 4. Configuration and models
 
@@ -313,15 +313,15 @@ One root Cargo.toml defines lib and bin. Modules cover configuration, providers,
 
 Dependencies include clap, tokio, reqwest, serde, serde_json, schemars, lancedb 0.38, arrow, parquet, image, sha2, indicatif, tracing, tract-onnx. axum/utoipa and optional rerun belong to the later serving/visualization milestones. Invoke ffmpeg as a subprocess.
 
-The initial macOS arm64 release binary measured approximately 228 MiB uncompressed on 2026-09-08. Final archive size and CPU throughput require release acceptance; the original 60 MB estimate is not a promise.
+Measure binary and archive sizes and CPU throughput on both targets during release acceptance.
 
-Every PR runs offline tests and two-platform builds. Protected-branch validation includes small real Gemini calls; never inject model keys into fork PRs.
+Every PR runs offline tests and two-platform builds. Maintainers run small real Gemini checks locally with their own credentials as part of the [release checklist](docs/releases.md). CI does not require a model key.
 
 ## 9. Acceptance
 
 | Milestone | Scope |
 | --- | --- |
-| **M1**, first release v0.0.3 | Index (transcript, OCR, embedding, still detection); search (vectors, images, prefilters, filter counts, saving clips, exact text); status; removal and disk reclamation; semantic annotation; LeRobot reading and subtask writeback; macOS/Linux distribution; replace the old npm cerul wrapper. |
+| **M1** | Index (transcript, OCR, embedding, still detection); search (vectors, images, prefilters, filter counts, saving clips, exact text); status; removal and disk reclamation; semantic annotation; LeRobot reading and subtask writeback; macOS/Linux distribution. |
 
 Acceptance requirements:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,7 +22,7 @@ cerul search "A person puts a cup on the table" --save ./clips
 On first use, enter your [Gemini API key](https://aistudio.google.com/apikey)
 when prompted. Model processing sends inputs to Gemini and may incur API charges.
 
-You can also download an archive from [GitHub Releases](https://github.com/cerul-ai/cerul/releases/tag/v0.0.5).
+You can also download an archive from [GitHub Releases](https://github.com/cerul-ai/cerul/releases/latest).
 Keep `cerul`, `cerul-ffmpeg`, and `cerul-ffprobe` together when moving them.
 
 ## Build from source (developers)
@@ -89,11 +89,9 @@ cerul --version
 cerul --json status
 ```
 
-These commands assume the checkout contains the root `Cargo.toml` and the
-`index`, `search`, and `annotate` CLI. If you are testing an unmerged change,
-use the branch or commit supplied by its author. Do not substitute the retired
-`apps/cli` client. The PATH change above applies to this shell; save it in your
-shell configuration only if you want a persistent installation at this location.
+To test an unmerged change, check out its branch or commit before building.
+The PATH change above applies to this shell; save it in your shell configuration
+only if you want a persistent installation at this location.
 
 `status` does not call a provider. It verifies that the CLI starts; it does not
 prove media processing or model connectivity. `--dry-run index` previews the
@@ -145,7 +143,8 @@ semantic-search setup. Configure a key and rerun the same command to finish.
 
 | Symptom | Next step |
 | --- | --- |
-| `ffmpeg` or `ffprobe` missing/too old | Install or update the media package, then verify both commands in the same terminal |
+| An older Cerul version runs after installation | Run `type -a cerul` to find competing installations, then put the new installer's directory first on PATH and open a new terminal |
+| `ffmpeg` or `ffprobe` missing/too old | Reinstall the complete Cerul bundle and keep all three executables together; for custom tools, check the overrides below |
 | Unknown encoder `libx264` | Use a build that includes this encoder |
 | Missing model credential | Set the endpoint's configured key environment variable without exposing the value |
 | Provider quota or rate limit | Lower `--jobs`, set an account-appropriate `--rpm`, and resume after quota is available |

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,21 +4,22 @@ Building or reviewing a branch never publishes a release.
 Package publishing is a separate release operation after M1 acceptance.
 Existing tags and `ffmpeg-vendor-*` assets must be preserved for downstream compatibility.
 
-## First public release
+## Release checklist
 
-The first release uses GitHub Releases and the website installer redirect.
-npm and Homebrew publishing can follow separately.
+Public installation uses GitHub Releases and the permanent website installer
+redirect. npm and Homebrew publication are separate from generating their artifacts.
 
 1. Verify PR checks and acceptance results, then merge the release PR into `main`.
 2. From the merged `main`, confirm Cargo.toml and packaging/dist.toml agree on
    the version being released, then create and push the matching tag. The
-   commands below use `0.0.5`; substitute the version in the manifests.
+   commands below use `X.Y.Z` as a placeholder; replace it with the version in
+   both manifests. Existing release tags must not be moved or reused.
 
    ```sh
    git switch main
    git pull --ff-only origin main
-   git tag -a v0.0.5 -m "Release Cerul 0.0.5"
-   git push origin v0.0.5
+   git tag -a vX.Y.Z -m "Release Cerul X.Y.Z"
+   git push origin vX.Y.Z
    ```
 
 3. Wait for the Release workflow to publish both platform archives, the shell
@@ -32,11 +33,13 @@ npm and Homebrew publishing can follow separately.
    credential is stored in the repository:
 
    ```sh
-   GEMINI_API_KEY=... cargo run --locked --example verify_gemini
+   cargo run --locked --example verify_gemini
    ```
 
-   The CLI's defaults name specific Gemini models, so this is what catches an
-   upstream model being retired or changed before users do.
+   Set `GEMINI_API_KEY` securely in your local environment before running this
+   command. The CLI's defaults name specific Gemini models, so this catches an
+   upstream model being retired or changed before users do. CI does not run
+   this check or require a model credential.
 6. On each supported platform, install from the public README command and verify
    `cerul --version`, video indexing, search, and clip export.
 7. Confirm the README installation command works from a clean terminal.
@@ -90,7 +93,7 @@ written under `target/distrib/`, including:
 - A source archive and aggregate checksums.
 
 The source archive uses committed Git content. Regenerate it after committing;
-an archive produced while this rewrite is uncommitted is not the release source.
+uncommitted changes are not included in the release source.
 Do not hand-edit generated release workflows or installers. Change the dist
 configuration and regenerate them.
 
@@ -105,13 +108,13 @@ cargo package --list --locked
 cargo package --locked
 ```
 
-The initial cleaned package measured 25.1 MiB compressed (93 files). Embedded
-OCR weights account for most of its size. This exceeds the default 10 MB limit
-documented in the [Cargo publishing guide](https://doc.rust-lang.org/cargo/reference/publishing.html).
-Before publishing to crates.io, confirm package ownership and an upload limit
-that accepts the final archive. No size exception has been verified. Keep the
-embedded OCR runtime contract; do not silently omit the weights or replace
-them with a first-run download to make the upload fit.
+Embedded OCR weights account for much of the package size. Measure the final
+`.crate` archive and confirm package ownership and the registry's upload limit
+before publishing to crates.io; see the
+[Cargo publishing guide](https://doc.rust-lang.org/cargo/reference/publishing.html).
+Registry publication is not configured by the release workflow. Keep the
+embedded OCR runtime contract; do not omit the weights or replace them with
+a first-run download to make the upload fit.
 
 ## Installation acceptance
 
@@ -134,13 +137,11 @@ separately only as part of an authorized release.
 ## Publishing boundary
 
 The generated GitHub workflow plans artifacts on pull requests and builds and
-hosts releases for matching version tags. This branch does not push a version
-tag. npm and Homebrew artifacts are generated, but registry/tap publishing is
-not configured: no Homebrew tap or registry credential is assumed.
+hosts releases for matching version tags. The permanent website redirect tracks
+the latest published release; it needs no per-release website change.
 
-Before an authorized publication, finish all DESIGN.md M1 acceptance gates,
-verify the committed source archive, confirm npm package ownership and the
-chosen Homebrew distribution destination, and configure the corresponding
-publisher. The desired `https://cerul.ai/install.sh` entry point also needs to
-be connected to the verified generated installer in the product website. Do
-not advertise these installation endpoints as live before they are verified.
+npm and Homebrew artifacts are generated, but registry/tap publishing is not
+configured. Before enabling those channels, confirm npm package ownership and
+the Homebrew distribution destination, configure their publishers, and verify
+installation through each public channel. A downloadable wrapper or formula
+alone does not establish registry/tap availability.


### PR DESCRIPTION
After the CLI relaunch, contributor instructions still describe the removed live-provider CI workflow, release notes still include pre-launch installer requirements, and issue templates point to retired platform directories.

Update the documentation and templates to match the current Rust core and CLI: document local release-time provider checks, the permanent installer redirect and separate registry publication, current module paths, and generated-schema checks. Keep the design and acceptance requirements, and correct provider-probe and query-cache descriptions.

Validation:
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`: 101 passed (run with local loopback ports permitted)
- `git diff --check`, 51 relative Markdown links, and all issue-template YAML files
- `cargo package --list --locked --allow-dirty`: source package contains no legacy client, build, or credential paths

No runtime code, generated release workflow, release tag, or published asset changes.
