### PR TITLE
Fix v0.0.6 dist version

### DIFF
--- a/packaging/dist.toml
+++ b/packaging/dist.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerul"
-version = "0.0.5"
+version = "0.0.6"
 description = "Searchable video and annotation data, using your own model endpoints"
 license = "Apache-2.0 AND GPL-2.0-or-later AND Zlib"
 homepage = "https://cerul.ai"


### PR DESCRIPTION
Align cargo-dist package metadata with the v0.0.6 Cargo package release.