### PR TITLE
Redesign the CLI output and let agents drive it through --json

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@ the behavior, storage contracts, and invariants implementations must preserve.
 
 | Area | Entry points | Responsibility |
 | --- | --- | --- |
-| CLI | [main.rs](src/main.rs), [render.rs](src/render.rs), [credentials.rs](src/credentials.rs) | Parse arguments, dispatch commands, render results, and manage interactive credential setup. |
+| CLI | [main.rs](src/main.rs), [render.rs](src/render.rs), [guide.rs](src/guide.rs), [credentials.rs](src/credentials.rs) | Parse arguments, dispatch commands, render results, complete an under-specified command at a terminal, and manage interactive credential setup. |
 | Library interface | [lib.rs](src/lib.rs), [config.rs](src/config.rs), [events.rs](src/events.rs) | Expose reusable operations, explicit configuration, and structured events. |
 | Media and time | [episode.rs](src/episode.rs), [media/](src/media), [ocr.rs](src/ocr.rs) | Discover media properties, map episode time, prepare model inputs, and run embedded OCR. |
 | Providers | [providers/](src/providers) | Call configured endpoints, validate capabilities, and resolve scoped credentials. |
@@ -63,7 +63,8 @@ implement product UI, hosted inference, or HTTP/MCP serving. See
 | [LICENSE](LICENSE), [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md), [packaging/licenses/](packaging/licenses) | Project license, bundled-component notices, and full third-party license texts. Preserve notices required by distributions. |
 | [models/README.md](models/README.md), [models/LICENSE](models/LICENSE), [models/characters.txt](models/characters.txt) | Model provenance, license, and a runtime OCR dictionary. The dictionary is data; whitespace changes can alter class decoding. |
 | [tests/fixtures/README.md](tests/fixtures/README.md), [docs/assets/README.md](docs/assets/README.md) | Fixture provenance and brand-asset usage notes next to their files. |
-| [prompts/](prompts) | Eight runtime Markdown prompts embedded by the semantic annotation code. Edit and validate them as processing behavior. |
+| [prompts/](prompts) | Runtime Markdown embedded in the binary: eight semantic annotation prompts, plus [skill.md](prompts/skill.md), the body of the agent skill. Edit and validate them as processing behavior. |
+| [skills/](skills) | The generated agent skill exactly as `cerul skill --install claude` writes it. Regenerate with `cerul skill --print > skills/cerul/SKILL.md` after changing commands or the prompt. |
 | [schemas/](schemas) | JSON contracts generated from Rust types by [generate_schemas.rs](examples/generate_schemas.rs); do not hand-edit them. |
 | `.github/` | Issue forms, PR template, ownership, dependency automation, and workflow YAML. GitHub consumes these files at their designated locations. |
 | [Cargo.toml](Cargo.toml), [Cargo.lock](Cargo.lock), `dist-workspace.toml`, `packaging/dist.toml` | Rust and distribution manifests and dependency resolution. These are executable build inputs, not user documentation. |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ include = [
     "/README.md", "/README.zh-CN.md", "/README.zh-TW.md", "/DESIGN.md", "/ARCHITECTURE.md", "/CONTRIBUTING.md",
     "/CODE_OF_CONDUCT.md", "/SECURITY.md",
     "/src/**/*.rs", "/examples/*.rs", "/docs/**/*.md",
-    "/packaging/licenses/*.txt", "/scripts/build-*.sh", "/scripts/test-*.py", "/scripts/check-docs.py", "/scripts/package-media-source.sh", "/schemas/*.json", "/prompts/*.md", "/docs/assets/*.png",
+    "/packaging/licenses/*.txt", "/scripts/build-*.sh", "/scripts/test-*.py", "/scripts/check-docs.py", "/scripts/package-media-source.sh", "/schemas/*.json", "/prompts/*.md", "/skills/cerul/SKILL.md", "/docs/assets/*.png",
     "/models/det.onnx", "/models/rec.onnx", "/models/characters.txt",
     "/models/LICENSE", "/models/README.md",
     "/tests/*.rs", "/tests/*.py",

--- a/README.md
+++ b/README.md
@@ -113,7 +113,13 @@ Copy this prompt into an agent that can use a terminal:
 Install Cerul by following https://github.com/cerul-ai/cerul/blob/main/docs/agent-setup.md. Help me set up my Gemini API key securely, search a local video, and save a matching clip. Teach me the commands in my language.
 ```
 
-[Agent setup guide →](docs/agent-setup.md)
+Agents that read skills can learn the whole command line from Cerul itself:
+
+```sh
+cerul skill --install claude    # also: codex, pi, or --dir ./skills
+```
+
+[Agent setup guide →](docs/agent-setup.md) · [Agent contract →](docs/agent.md)
 
 ## More things to try
 

--- a/design/cli-interaction/README.md
+++ b/design/cli-interaction/README.md
@@ -1,0 +1,12 @@
+# CLI interaction design
+
+The design the Cerul command line follows, kept as the record of what was
+decided and why. It is not user documentation: people reading it as users want
+[docs/README.md](../../docs/README.md) instead, and agents want
+[docs/agent.md](../../docs/agent.md).
+
+- [v2/COMMANDS.md](v2/COMMANDS.md): the shared output grammar and every screen.
+- [v2/AGENT-MODE.md](v2/AGENT-MODE.md): the `--json` contract and the shipped skill.
+
+An earlier iteration catalogued 64 reference scenes. It proved too abstract to
+review, and lives on the `codex/cli-interaction-design` branch rather than here.

--- a/design/cli-interaction/v2/AGENT-MODE.md
+++ b/design/cli-interaction/v2/AGENT-MODE.md
@@ -51,9 +51,13 @@ it published:
 }
 ```
 
-`retry` is present on a partial result. It repeats every original argument and
-changes only what the failure suggests; `--recompute` is never added. An agent
-can run `retry.argv` verbatim.
+`retry` is present on a partial result, and it is part of the generated schema
+rather than a field added beside it, so a client built from `schemas/` knows the
+recovery exists. It repeats every original argument, including any completed by
+guidance, and changes only what the failure suggests; `--recompute` is never
+added. An agent can run `retry.argv` verbatim. A cancelled run has no result
+object at all, only an error with code `cancelled`; the same command run again
+resumes it.
 
 The draft proposed a separate `outputs` array. It was dropped during
 implementation: `modules[]` already is that list once each entry carries its own
@@ -130,12 +134,16 @@ cerul skill --install claude  ~/.claude/skills/cerul/SKILL.md
 cerul skill --install codex   ~/.codex/skills/cerul/SKILL.md
 cerul skill --install pi      ~/.pi/agent/skills/cerul/SKILL.md
 cerul skill --dir DIR         any other skills directory
+cerul skill --install claude --force   replace a skill that was changed
 ```
 
-Receipt: `✓ Wrote ~/.claude/skills/cerul/SKILL.md (cerul 0.0.7)`. The file
-records the CLI version in its front matter; a later `--install` overwrites
-only a file that carries the same `generated-by: cerul` marker, never a
-user-edited one, and says so. Listed under `Maintain` in root help.
+Receipt: `✓ Wrote ~/.claude/skills/cerul/SKILL.md (cerul 0.0.6)`. The file records
+the CLI version in its front matter. Installing replaces a file an older build
+wrote, because that is an upgrade. It refuses when the file carries this build's
+version but no longer matches what this build writes, because that means somebody
+edited it; `--force` is the way past that. A file with no marker at all is never
+replaced. Printing the skill, or writing it to a named directory, needs neither a
+workspace nor a home directory.
 
 ## 3. Documentation
 

--- a/design/cli-interaction/v2/AGENT-MODE.md
+++ b/design/cli-interaction/v2/AGENT-MODE.md
@@ -1,0 +1,165 @@
+# Agent mode: letting other people's agents drive Cerul
+
+Goal: a coding agent (Claude Code, Codex, pi, Cursor, or a hand-written loop)
+should be able to install, configure, and operate Cerul without reading the
+repository, and without Cerul embedding an agent of its own. Three pieces
+deliver that: a machine contract that already mostly exists (`--json`), a
+shipped skill that teaches the contract, and a command that installs the skill
+where each agent looks for it.
+
+Nothing here adds HTTP or MCP serving. DESIGN.md keeps those unimplemented and
+unadvertised; subprocess JSON is the sanctioned integration path.
+
+## 1. The contract is `--json`
+
+There is no separate agent flag. `--json` is agent mode:
+
+- stdout: exactly one final JSON object, schema per command under `schemas/`.
+- stderr: one NDJSON event per line.
+- exit codes: 0 ok, 2 arguments or configuration, 3 dependency or capability,
+  4 execution, 5 cancelled, 6 partial.
+- never prompts, never draws, never asks for a key. Missing arguments return
+  `{"error":"invalid_arguments", ...}` with an example command.
+
+### 1.1 Event vocabulary
+
+Today `events.rs` has `progress` and `log`. Agents waiting on a long
+`annotate` need to know when something usable appeared and how to recover.
+Add three events; all fields are stable and documented in `schemas/event.json`.
+
+```jsonl
+{"event":"progress","episode":"demo","station":"semantic.subtask","done":3,"total":5}
+{"event":"published","episode":"demo","annotation":"semantic.subtask","records":12,"path":"/v/demo.mp4.cerul/semantic.subtask.jsonl"}
+{"event":"checkpoint","episode":"demo","station":"semantic.event","window":3,"total":5}
+{"event":"log","level":"info","msg":"Indexing started"}
+```
+
+`published` fires only after validation and atomic publication. `checkpoint`
+fires when a window is durably saved and will be reused by a rerun.
+
+### 1.2 Final object additions
+
+The annotate result gains `retry`, and each module gains the path of the file
+it published:
+
+```json
+{
+  "modules": [{"episode":"demo","annotation":"semantic.subtask","records":12,
+               "source":"/v/demo.mp4","dataset":false,"path":"…/semantic.subtask.jsonl"}],
+  "retry":   {"argv":["cerul","annotate","/v/demo.mp4","--semantic","subtask,event","--rpm","6"],
+              "reason":"rate_limit"}
+}
+```
+
+`retry` is present on a partial result. It repeats every original argument and
+changes only what the failure suggests; `--recompute` is never added. An agent
+can run `retry.argv` verbatim.
+
+The draft proposed a separate `outputs` array. It was dropped during
+implementation: `modules[]` already is that list once each entry carries its own
+`path`, and two copies of one fact in one object is a defect waiting to happen.
+
+### 1.3 Read-only views agents need
+
+- `cerul --json status [path]`: unchanged, plus `--timeline` returning
+  sidecar records in time order with `--type` and `--limit`. This is how an
+  agent answers "what did you find" without parsing JSONL itself.
+- `cerul --json auth`: reports `saved`, `env_set`, `credentials_path`; never
+  a value or prefix.
+- `cerul --json --dry-run <anything>`: plan without writes, probes, or model
+  calls.
+
+## 2. The skill
+
+One file in the Agent Skills format (YAML front matter plus Markdown body),
+readable by Claude Code, Codex, pi, and any tool that follows the same
+convention. It is the only document an agent needs.
+
+### 2.1 Source of truth
+
+`prompts/skill.md` holds the hand-written parts (when to use, workflow,
+safety rules). The command reference section is generated from the clap
+definitions at build time, so it can never drift from `--help`. A test asserts
+`cerul skill --print` equals the committed copy at `skills/cerul/SKILL.md`,
+which exists so people can install from GitHub without running anything.
+
+### 2.2 Structure
+
+```markdown
+---
+name: cerul
+description: Search local videos by meaning, exact words, or a reference image, and
+  annotate actions, events, interactions, and states in videos or LeRobot datasets.
+  Use when the user mentions video search, clips, video annotation, egocentric or
+  robot demonstrations, or LeRobot. Requires the cerul CLI.
+---
+
+# Cerul
+
+## Check first
+`cerul --version`; if missing, follow docs/agent-setup.md (install.sh, no Rust).
+`cerul --json auth` for key presence. Never echo, log, or copy a key.
+
+## Always use --json
+stdout final object, stderr NDJSON events, exit codes 0/2/3/4/5/6.
+Exit 6 is partial, not success. Run `retry.argv` from the final object.
+
+## Workflows
+Search:   cerul --dry-run index P → cerul --json index P → cerul --json search "Q" --in P
+Annotate: cerul --json --dry-run annotate P --semantic subtask,event,interaction,state
+          → same without --dry-run → cerul --json status P --timeline
+LeRobot:  cerul --json annotate DATASET --semantic --only 0 → status DATASET --timeline
+Clips:    cerul --json search "Q" --save DIR
+
+## Rules
+- Ask before any command that sends media to a model endpoint; say it is billed.
+- Do not run status --providers unless asked; it makes model requests.
+- Do not delete lock files, change dataset version labels, or add --recompute.
+- Use one --workspace consistently.
+
+## Command reference
+<generated from clap: every command, every option, defaults>
+```
+
+### 2.3 `cerul skill`
+
+```text
+cerul skill                   where it can go, and where it already is
+cerul skill --print           write SKILL.md to stdout
+cerul skill --install claude  ~/.claude/skills/cerul/SKILL.md
+cerul skill --install codex   ~/.codex/skills/cerul/SKILL.md
+cerul skill --install pi      ~/.pi/agent/skills/cerul/SKILL.md
+cerul skill --dir DIR         any other skills directory
+```
+
+Receipt: `✓ Wrote ~/.claude/skills/cerul/SKILL.md (cerul 0.0.7)`. The file
+records the CLI version in its front matter; a later `--install` overwrites
+only a file that carries the same `generated-by: cerul` marker, never a
+user-edited one, and says so. Listed under `Maintain` in root help.
+
+## 3. Documentation
+
+- `docs/agent.md`: the contract in one page (streams, exit codes, events,
+  final-object fields, schemas, `retry`). Linked from README's agent section.
+- `docs/agent-setup.md`: unchanged runbook, plus one line: install the skill
+  first with `cerul skill --install claude`.
+- `llms.txt` on cerul.ai pointing at `docs/agent.md` and the skill is a
+  website change, outside this repository.
+
+## 4. Not in scope
+
+MCP or HTTP serving, an embedded agent, tool-call adapters per vendor, or a
+plugin marketplace listing. If a vendor-specific package (a Claude Code
+plugin, a pi package) becomes worthwhile, it wraps the same SKILL.md and the
+same `--json` contract.
+
+## 5. Verification
+
+- Pipe tests for each `--json` command: single stdout object, NDJSON stderr,
+  documented exit code, `retry.argv` re-parses with clap.
+- Schema test: `schemas/event.json` and per-command final objects regenerate
+  from Rust types with no diff.
+- Skill test: `cerul skill --print` equals `skills/cerul/SKILL.md`; front
+  matter parses; every command in the reference exists in clap.
+- One real run: an agent given only SKILL.md completes annotate on a short
+  clip and reads the timeline, on macOS arm64 and Linux x86_64.

--- a/design/cli-interaction/v2/AGENT-MODE.md
+++ b/design/cli-interaction/v2/AGENT-MODE.md
@@ -51,9 +51,11 @@ it published:
 }
 ```
 
-`retry` is present on a partial result, and it is part of the generated schema
-rather than a field added beside it, so a client built from `schemas/` knows the
-recovery exists. It repeats every original argument, including any completed by
+`retry` is present on a partial **annotate** result, and it is part of the
+generated schema rather than a field added beside it, so a client built from
+`schemas/` knows the recovery exists. It is the only command that offers one:
+`index` and `status --providers` can also exit 6, and there the recovery is to
+run the same command again. It repeats every original argument, including any completed by
 guidance, and changes only what the failure suggests; `--recompute` is never
 added. An agent can run `retry.argv` verbatim. A cancelled run has no result
 object at all, only an error with code `cancelled`; the same command run again
@@ -139,10 +141,10 @@ cerul skill --install claude --force   replace a skill that was changed
 
 Receipt: `✓ Wrote ~/.claude/skills/cerul/SKILL.md (cerul 0.0.6)`. The file records
 the CLI version in its front matter. Installing replaces a file an older build
-wrote, because that is an upgrade. It refuses when the file carries this build's
-version but no longer matches what this build writes, because that means somebody
-edited it; `--force` is the way past that. A file with no marker at all is never
-replaced. Printing the skill, or writing it to a named directory, needs neither a
+wrote, because that is an upgrade. It records a digest of what it wrote, so it can tell its own untouched
+copy from one somebody changed whichever build wrote it, and refuses the latter;
+`--force` is the way past that. A file with no digest at all is never replaced.
+`--install` and `--dir` are two destinations and cannot both be given. Printing the skill, or writing it to a named directory, needs neither a
 workspace nor a home directory.
 
 ## 3. Documentation

--- a/design/cli-interaction/v2/COMMANDS.md
+++ b/design/cli-interaction/v2/COMMANDS.md
@@ -1,0 +1,413 @@
+# Cerul CLI interaction design, v2
+
+Status: design for review. Supersedes the 64-scene catalog in the parent
+directory by narrowing it to the screens a person actually meets. No Rust
+changes are part of this document. DESIGN.md stays the implementation baseline;
+everything here is presentation and TTY-only guidance layered on the existing
+command contracts.
+
+Direction confirmed by the owner: command line with lightweight guidance.
+No full-screen TUI and no embedded agent in this iteration. Agents call the
+CLI through `--json` and a shipped skill; see [AGENT-MODE.md](AGENT-MODE.md).
+
+## 1. Shared grammar
+
+Every human-facing screen is built from the same five parts, in this order.
+Not every screen needs all five, but the order never changes.
+
+| Part | Rule |
+| --- | --- |
+| Title | One line: state glyph, verb, subject, and the one number that matters (`✓ Annotated demo.mp4 in 01:48`). |
+| Facts | Two-space indented `label  value` rows, labels left-aligned in one column. Real paths, real counts. |
+| Live area | stderr only, TTY only. One line per unit of work with a glyph. Collapses to one line when the unit finishes. |
+| Receipt | stdout. What was produced and where, as paths the shell can use. |
+| Next | Heading `Next`, one to three full commands with a short reason. Never more than three. |
+
+Glyphs carry state without color: `✓` done, `◐` in progress, `·` queued or
+not applicable, `!` partial, `✗` failed, `❯` current choice. Color is one
+accent for commands and the current choice, green for done, amber for partial
+and cancelled, red for failed, dim for metadata. No emoji in default output;
+the current search card glyphs (🔍 📊 🕐 🎬) go.
+
+Width: 80 columns is the layout target. Below 80, fact rows stack; paths and
+commands wrap at word boundaries and are never truncated. Times are `mm:ss`
+or `hh:mm:ss` for people; microseconds stay in JSON.
+
+Streams: results on stdout, progress and prompts on stderr. Redirected output
+is append-only, no cursor movement, no images. `NO_COLOR` removes color;
+a non-TTY removes control sequences independently.
+
+Guidance gate: interactive prompts appear only when stdin and stderr are TTYs
+and none of `--json`, `--yes`, `-q`, `--dry-run` is set. This is the predicate
+`confirm()` already uses in `main.rs`; the guided screens reuse it. Every
+guided flow ends by printing the exact equivalent command, shell-quoted, so the
+second run never needs the guide.
+
+## 2. Home: `cerul`
+
+TTY:
+
+```text
+cerul 0.0.7  ·  Search and annotate your videos
+
+Workspace  ~/.cerul     8 videos · 6 searchable · 3 annotated
+Models     Gemini       key saved · endpoints not checked this run
+
+What do you want to do?
+❯ Index videos so they can be searched
+  Search indexed videos
+  Annotate actions in a video or LeRobot dataset
+  Show status
+  Quit
+
+↑↓ move · Enter select · Esc quit                or: cerul index ./video.mp4
+```
+
+Selecting an item runs the matching guided flow below. Esc or Quit exits 0
+with nothing written. Redirected or `--json`: the existing read-only home
+(status summary plus three example commands), no menu, no numbering that looks
+pressable.
+
+First run (no key, nothing indexed) keeps the current four-step "Get started"
+list; the menu is offered underneath it once a key exists.
+
+## 3. Annotate
+
+### 3.1 Guided: `cerul annotate` with no path
+
+Three questions, then run. Bare `annotate` in a non-TTY keeps today's
+`invalid_arguments` error and example block.
+
+```text
+Annotate  ·  which video or dataset?
+❯ demo.mp4              02:30
+  kitchen.mp4           04:12
+  egodemo/              LeRobot v3.1 · 24 episodes
+  Type a path…
+
+Only this directory is listed. Nothing is read until you start.
+```
+
+Directory listing is non-recursive, media files and LeRobot roots only,
+capped at 12 entries, most recent first. Typing a path validates existence
+and layout before continuing.
+
+```text
+Annotate  ·  demo.mp4  ·  what is in it?
+❯ A robot or first-person demonstration     subtask, event, interaction, state
+  A general video                            task, subtask, flag
+  Everything                                 all seven semantic types
+```
+
+Presets are named by what the user has, not by label names. They expand to
+existing `--semantic` lists; no new flags. For a LeRobot root an extra step
+picks episodes (`0`, a list, or all; default `0`) and cameras (primary or all)
+from the real discovery result, and the third preset is the default.
+
+```text
+Annotate  ·  ready
+
+  Input     demo.mp4 · 02:30 · primary camera
+  Labels    subtask, event, interaction, state
+  Model     Gemini gemini-3.8-flash · frames are sent to it, billed to your key
+  Output    ./demo.mp4.cerul/semantic.<type>.jsonl
+
+  cerul annotate ./demo.mp4 --semantic subtask,event,interaction,state
+
+❯ Start
+  Preview only (--dry-run)
+  Cancel
+```
+
+No cost or time estimate is invented. Start executes exactly the printed
+command through the normal argument path.
+
+### 3.2 Running
+
+```text
+Annotating demo.mp4   subtask · event · interaction · state
+  Gemini gemini-3.8-flash · output ./demo.mp4.cerul/
+
+✓ subtask        5/5 windows   12 records   published
+◐ event          3/5 windows
+◐ interaction    2/5 windows
+· state          queued
+
+00:42 elapsed · Ctrl+C stops after the current window; finished work is kept
+```
+
+Window counts appear only when known. "published" appears only after
+validation and atomic publication, never for checkpoints. For several inputs
+the finished ones collapse to one line each and the live block shows the
+current input, as `index` does today.
+
+### 3.3 Receipt
+
+```text
+✓ Annotated demo.mp4 in 01:48
+
+  subtask        12 records   ./demo.mp4.cerul/semantic.subtask.jsonl
+  event          18 records   ./demo.mp4.cerul/semantic.event.jsonl
+  interaction     9 records   ./demo.mp4.cerul/semantic.interaction.jsonl
+  state          14 records   ./demo.mp4.cerul/semantic.state.jsonl
+
+Next
+  cerul status ./demo.mp4 --timeline              read the labels in order
+  cerul search --filter semantic.event.verb=grasp  find one action across videos
+
+Labels are model-generated; review them before training on them.
+```
+
+LeRobot receipts group by episode and camera and end with
+`cerul status ./dataset --timeline`.
+
+### 3.4 Partial, cancelled, failed
+
+```text
+! Annotated demo.mp4 partially                                       exit 6
+
+  ✓ subtask        12 records   published
+  ✓ event          18 records   published
+  ✗ interaction    stopped at window 3/5 · Gemini rate limit (429)
+  · state          not started
+
+Finished windows are saved and reused. Retry with a lower request rate:
+  cerul annotate ./demo.mp4 --semantic subtask,event,interaction,state --rpm 6
+```
+
+The retry command repeats every original argument and changes only what the
+error suggests. `--recompute` is never added automatically. Ctrl+C prints the
+same block with `cancelled` and exit 5 and the unchanged command as the retry.
+
+## 4. Timeline: `cerul status <path> --timeline`
+
+New read-only view over sidecars. It is the "did it work?" screen and the
+cheapest way to judge label quality without opening JSONL. `--json` returns the
+records unchanged from the sidecar schema.
+
+```text
+demo.mp4  02:30  ·  subtask event interaction state  ·  ./demo.mp4.cerul/
+
+  00:00 – 00:14   subtask       reach for the cup
+  00:03           event         grasp cup
+  00:14 – 00:31   subtask       lift cup to mouth
+  00:20           state         cup · on table → in hand
+  00:31 – 00:52   subtask       drink
+  00:52           interaction   hand releases cup
+
+showing 6 of 53 records · --type event · --limit 100
+```
+
+## 5. Index
+
+`cerul index` with no path asks one question (which video or folder, same
+picker as annotate) and runs. With arguments it prints the plan line first,
+as today.
+
+```text
+Indexing 3 videos   screen text (local) · speech (Gemini) · search index (Gemini)
+
+✓ cup-demo.mp4      02:30   screen text · speech · search ready
+◐ silent.mp4        02:10
+    screen text     180/260 frames
+    speech          no audio track
+    search          2/5 windows
+· assembly.mp4      04:02   queued
+
+01:18 elapsed
+```
+
+Receipt:
+
+```text
+✓ 3 videos ready to search   08:42 of media in 03:05
+
+  screen text    3 videos          speech    2 videos · 1 had no audio
+  indexes        ./videos/*.cerul  vectors   ~/.cerul/index/
+
+Next
+  cerul search "a person picking up a cup"
+  cerul search --text "ERROR 500"
+```
+
+Offline or missing-key runs report local stations as done and remote ones as
+`not indexed · no Gemini key`, exit 6, and recommend only `--text` search.
+
+## 6. Search
+
+`cerul search` with no query asks `Search for:` on one line and runs.
+Image and filter searches stay flag-only. Results:
+
+```text
+3 moments for "a person picking up a cup"   in 2 videos
+
+  cup-demo.mp4
+  [1]  00:12 → 00:19   similarity 82%    visual
+       A person lifts a ceramic cup from the table.
+  [2]  01:04 → 01:10   similarity 77%    visual
+       A hand picks up the cup beside a notebook.
+
+  kitchen.mp4
+  [3]  00:42 → 00:48   similarity 71%    speech
+       "Pick up the cup and place it here."
+
+Next
+  cerul open 1                                  play the first moment
+  cerul search "a person picking up a cup" --save ./clips
+```
+
+Changes from today: the box-drawing card frame and emoji go; `similarity
+82%` replaces `82% match` (a label change only; the number and the ranking
+stay as they are, and README needs no edit); numbering is
+global and identical to `open N` even when grouped by video; still frames stay
+where the terminal supports them, placed under the `[N]` line. `--text`
+results show `exact · screen text` or `exact · speech` and no similarity.
+`--count` keeps its one-line answer.
+
+Empty:
+
+```text
+No matches for "a person juggling"   in 6 searchable videos
+
+  cerul search --text "juggling"      exact words on screen or in speech
+  cerul status                        which videos are searchable
+```
+
+Missing indexes, unavailable model, and invalid query are separate errors
+(section 10), never an empty result.
+
+## 7. Open
+
+```text
+▶ Playing cup-demo.mp4 from 00:12 in mpv                          result 1 of 3
+```
+
+Fallback: `▶ Opening cup-demo.mp4 in the system player · it cannot start at
+00:12, seek there yourself`. No search yet: `error: no search to open from`
+with `cerul search "..."` as the hint. Out of range: names the valid range.
+
+## 8. Status
+
+```text
+Workspace ~/.cerul   ·   cerul 0.0.7
+
+  Video               Length   Search    Text   Speech     Annotations
+  cup-demo.mp4        02:30    ready     ✓      ✓          subtask event
+  silent.mp4          02:10    ready     ✓      no audio   –
+  assembly.mp4        04:02    partial   ✓      ✗          –
+  egodemo/ · 24 ep    18:40    –         –      –          ep 0 · 4 types
+
+Models    Gemini    gemini-embedding-2 (1536d) · gemini-3.8-flash · key saved
+Storage   3 indexes beside videos · 1 vector space · OCR runs locally
+
+cerul status <path> for files and the annotation timeline
+```
+
+Below 80 columns the table becomes one block per video. `status <path>`
+lists every sidecar file with counts and offers `--timeline`. `--providers`
+adds a `Checked` line with the probe time per endpoint.
+
+## 9. Auth and remove
+
+```text
+$ cerul auth set
+Gemini API key (hidden):
+Checking  ✓ embedding · ✓ vision · ✓ transcription
+Saved to ~/.cerul/credentials.toml (0600) · GEMINI_API_KEY in the environment overrides it
+
+Next
+  cerul index ./video.mp4                  make it searchable
+  cerul annotate ./video.mp4 --semantic    label actions
+```
+
+Failed verification keeps the previous key and says which check failed and
+why (rejected, timeout, quota, unsupported). Removal says the local copy is
+gone, environment keys still apply, and nothing was revoked remotely.
+
+```text
+$ cerul remove ./demo.mp4
+Forget demo.mp4?
+  deletes   ./demo.mp4.cerul/          annotations and vectors · regenerating costs model calls
+  deletes   its rows in 1 search index
+  keeps     ./demo.mp4
+
+Remove? [y/N] y
+✓ Forgot demo.mp4 · freed 14 MB
+```
+
+`--cache`, `--all-indexes`, `--index`, `--compact` each print the same
+`deletes / keeps` block with their own scope and do not ask, as today. The
+receipt for `--cache` says a later query may need one embedding call; for
+indexes it says rebuild needs no model calls.
+
+## 10. Errors
+
+Four lines, always in this order: what failed, what it affected, the safe
+next action as a full command, what was preserved. Exit code right-aligned on
+the last line.
+
+```text
+✗ Workspace is busy
+  ~/.cerul is locked by another cerul process started 00:04:12 ago.
+  Wait for it, or use a separate workspace:
+    cerul --workspace ./ws annotate ./demo.mp4 --semantic
+  Nothing was changed.                                                 exit 4
+```
+
+Categories keep their current codes: 2 arguments and configuration, 3 missing
+dependency or unsupported capability, 4 execution, 5 cancelled, 6 partial.
+Missing key, invalid config, unsupported capability, rate limit, connection
+failure, and lock contention each have their own message; none suggests
+deleting a lock file or switching providers.
+
+## 11. Help
+
+Root help groups commands by task and lists global options in full:
+
+```text
+Process    index      make videos searchable
+           annotate   label actions, events, interactions, and states
+Explore    search     find moments or annotation records
+           open       play a result from the last search
+           status     videos, files, timeline, and model setup
+Maintain   auth       manage the saved Gemini key
+           remove     free caches, indexes, or a video's data
+           skill      print or install the agent skill
+```
+
+`completions` stays hidden. Command help keeps the current
+"examples, then input and output, then grouped options" order. Help never
+starts a guide.
+
+## 12. Implementation notes
+
+- Binary only. A `guide` module beside `render.rs`, declared from `main.rs`;
+  the library never sees a terminal. This is also the moment to split the
+  1,200-line `main.rs` into `cli/args.rs`, `cli/run.rs`, `cli/guide.rs`.
+- Prompts use `dialoguer` (same author as the existing `indicatif` and
+  `console`, no new terminal backend). Select, Input, Confirm only.
+- `paths` becomes optional at the clap level for `index` and `annotate`;
+  the dispatch layer either runs the guide or returns today's error, so the
+  JSON `invalid_arguments` tests keep passing.
+- Guided choices build the same `Args` structs the parser produces; the
+  printed command is derived from them with a small shell-quoting helper.
+- Receipt, partial, timeline, status table, search card, and error changes
+  are pure `render.rs` work and ship first, before any prompt.
+- Acceptance: PTY tests (guide appears, Esc leaves nothing behind, paths
+  with spaces quote correctly, guided run equals typed command); pipe tests
+  (no prompt, no ANSI, streams and exit codes unchanged); visual check at
+  60, 80, 100 columns, dark, light, `NO_COLOR`.
+
+## 13. Order of work
+
+| Step | Scope | New dependency |
+| --- | --- | --- |
+| 1 | Receipts, partial and cancel blocks, error grammar, search card, status table, timeline view | none |
+| 2 | Agent skill command and JSON events ([AGENT-MODE.md](AGENT-MODE.md)) | none |
+| 3 | Guided `annotate`, `index`, `search`; home menu | dialoguer |
+| 4 | LeRobot episode and camera picker | none |
+
+Owner decisions recorded: the ordinary-video `--semantic` default stays
+`task,subtask,flag` (the guide's first preset is an explicit choice, not a new
+default); the search score is shown as `similarity 82%`; the home menu lists
+index and search before annotate.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ reading command or compatibility details.
 
 - [Install and troubleshoot](installation.md)
 - [Install with an agent](agent-setup.md)
+- [Drive Cerul from an agent](agent.md)
 - [Search videos and save clips](video-search.md)
 - [Annotate actions and demonstrations](annotation.md)
 - [Annotate LeRobot subtasks](lerobot-subtasks.md)

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -12,6 +12,18 @@ Help me configure my Gemini API key securely, search a local video, and save a
 matching clip. Teach me the commands in my language.
 ```
 
+## Teach the agent the command line
+
+Once `cerul` is installed, it can write its own instructions into the agent's
+skills directory, generated from the build that is actually installed:
+
+```sh
+cerul skill --install claude
+```
+
+`codex`, `pi`, and `--dir ./skills` work the same way. The full machine contract
+is in [driving Cerul from an agent](agent.md).
+
 ## Agent workflow
 
 ### 1. Check the platform

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,0 +1,128 @@
+# Driving Cerul from an agent
+
+Cerul is a command-line program, and that is its whole interface for automation.
+There is no HTTP server, no MCP server, and no account: an agent runs the binary,
+reads one JSON object, and reads the exit code. This page is the contract. The
+[installation runbook](agent-setup.md) covers getting the binary onto a machine.
+
+## Install the skill
+
+```sh
+cerul skill --install claude    # ~/.claude/skills/cerul/SKILL.md
+cerul skill --install codex     # ~/.codex/skills/cerul/SKILL.md
+cerul skill --install pi        # ~/.pi/agent/skills/cerul/SKILL.md
+cerul skill --dir ./skills      # anywhere else
+cerul skill --print             # read it, or pipe it somewhere
+```
+
+The file is written in the Agent Skills format: YAML front matter with a `name`
+and a `description`, then Markdown. Its command reference is generated from this
+build's own argument definitions, so it always matches `cerul --help`. A copy of
+the same file lives at [`skills/cerul/SKILL.md`](../skills/cerul/SKILL.md) for
+people who would rather read it on GitHub or vendor it into a repository.
+
+Installing replaces a file Cerul wrote before, recognised by the
+`generated-by: cerul` line in its front matter. A file without that line is left
+alone and the command fails, so a hand-edited skill is never overwritten.
+
+## The `--json` contract
+
+`--json` is agent mode. There is no second flag to remember.
+
+| Stream | Contents |
+| --- | --- |
+| stdout | Exactly one JSON object, written when the command finishes. |
+| stderr | One JSON event per line, written while it runs. |
+
+Prompts never appear. A missing or invalid argument returns
+`{"error":{"code":"invalid_arguments","message":"…"}}` and exit 2 instead of a
+question. `cerul auth set` refuses in this mode rather than reading a key from a
+pipe.
+
+Exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 2 | Arguments or configuration |
+| 3 | Unavailable dependency or capability |
+| 4 | Execution failure |
+| 5 | Cancelled |
+| 6 | Partial success |
+
+Exit 6 is not success. Some work finished and the rest did not; read `retry`.
+
+## Events
+
+```jsonl
+{"event":"progress","episode":"demo","station":"semantic.subtask","done":3,"total":5}
+{"event":"checkpoint","episode":"demo","station":"semantic.subtask","window":3,"total":5}
+{"event":"published","episode":"demo","stream":"video","annotation":"semantic.subtask","records":12,"path":"/v/demo.mp4.cerul/semantic.subtask.jsonl"}
+{"event":"log","level":"info","msg":"Indexing started"}
+```
+
+- `progress` counts units of work for one station. Its units differ by station:
+  frames for screen text, segments for speech, batches for embedding, windows for
+  annotation.
+- `checkpoint` marks a window that is saved and will be reused after an
+  interruption. A rerun resumes from there instead of paying for it again.
+- `published` marks a validated annotation file that now exists on disk, with its
+  record count and path. **A checkpoint is not a published file.** Only a
+  published module is safe to read or train on.
+- `log` carries a human-readable notice, including the one-per-endpoint notice
+  before media is sent to a model.
+
+The schema for these lives in [`schemas/event.json`](../schemas/event.json).
+
+## Final objects
+
+Each command's final object is documented by a generated schema in
+[`schemas/`](../schemas/). Two fields matter most to an agent.
+
+**`modules[].path` on an annotate result** is where a published annotation file
+is. It is absent while a module is incomplete, because there is no file to point
+at yet.
+
+**`retry`** appears on a partial annotate result and carries the command that
+continues the work:
+
+```json
+{
+  "retry": {
+    "argv": ["cerul", "annotate", "/v/demo.mp4", "--semantic", "subtask,event", "--rpm", "6"],
+    "reason": "rate_limit"
+  }
+}
+```
+
+`argv` repeats the original invocation and changes only what the failure calls
+for; run it verbatim. `reason` is `rate_limit` when a provider limited the run and
+`incomplete` otherwise. Never add `--recompute` to a retry: it discards finished
+work and pays for it again.
+
+## Reading results back
+
+```sh
+cerul --json status                      # every video, with what each one has
+cerul --json status ./video.mp4          # one video and its files
+cerul --json status ./video.mp4 --timeline --type event --limit 100
+```
+
+`--timeline` returns published annotation records in time order, each with the
+original record plus a one-line `summary`. It reads sidecars only: no model call,
+no network, no lock. Use it instead of parsing JSONL directly.
+
+`cerul --json auth` reports whether a key is saved or exported, never its value.
+
+## Rules that keep a run honest
+
+- Ask before any command that sends media to a model endpoint, and say the
+  user's provider bills it. Local OCR is the exception; it runs on the CPU.
+- Preview with `--dry-run` first. It writes nothing, calls no model, probes no
+  endpoint, and asks for no credential.
+- Do not run `status --providers` unless asked. It makes real model requests.
+- Never delete a lock file, relabel a dataset version, or switch providers to get
+  past an error.
+- Keep one `--workspace` for a whole task.
+- `score` on a search hit is a ranking similarity, not a probability that the
+  moment is the right one. Do not present it as confidence or accuracy.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -21,9 +21,11 @@ build's own argument definitions, so it always matches `cerul --help`. A copy of
 the same file lives at [`skills/cerul/SKILL.md`](../skills/cerul/SKILL.md) for
 people who would rather read it on GitHub or vendor it into a repository.
 
-Installing replaces a file Cerul wrote before, recognised by the
-`generated-by: cerul` line in its front matter. A file without that line is left
-alone and the command fails, so a hand-edited skill is never overwritten.
+Cerul records a digest of the file it wrote in the front matter, so installing
+can tell its own untouched copy from one somebody changed, whichever build wrote
+it. An untouched copy is replaced, which is how an upgrade works. Anything else
+is left alone and the command fails, so a hand-edited skill is never overwritten;
+`--force` replaces it when that is what you want.
 
 ## The `--json` contract
 
@@ -76,16 +78,29 @@ The schema for these lives in [`schemas/event.json`](../schemas/event.json).
 
 ## Final objects
 
-Each command's final object is documented by a generated schema in
-[`schemas/`](../schemas/). Two fields matter most to an agent.
+`index`, `search`, `status`, `status --timeline`, `annotate`, and `remove`
+each have a generated schema in [`schemas/`](../schemas/), produced from the Rust
+result types. `auth`, `open`, and `skill` return small objects with no generated
+schema; their shapes are:
+
+```json
+{"provider":"gemini","endpoint":"…","env":"GEMINI_API_KEY","env_set":false,"saved":true,"credentials_path":"…","action":"set"}
+{"media":"/v/demo.mp4","start_us":12000000,"player":"mpv","seeks":true,"opened":true}
+{"version":"0.0.6","installed":"…/SKILL.md","targets":{"claude":"…"},"skill":"---\nname: cerul\n…"}
+```
+
+`auth` never reports a key's value, or any part of one. Two fields on the
+generated results matter most to an agent.
 
 **`modules[].path` on an annotate result** is where a published annotation file
 is. It is absent while a module is incomplete, because there is no file to point
 at yet.
 
-**`retry`** appears on a partial annotate result and carries the command that
-continues the work. A cancelled run has no result object at all, only an error
-with code `cancelled` and exit 5; the same command run again resumes it.
+**`retry`** appears on a partial **annotate** result and carries the command that
+continues the work. It is the only command that offers one: `index` and
+`status --providers` can also exit 6, and there the recovery is to run the same
+command again. A cancelled run has no result object at all, only an error with
+code `cancelled` and exit 5; the same command run again resumes it.
 
 ```json
 {

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -84,7 +84,8 @@ is. It is absent while a module is incomplete, because there is no file to point
 at yet.
 
 **`retry`** appears on a partial annotate result and carries the command that
-continues the work:
+continues the work. A cancelled run has no result object at all, only an error
+with code `cancelled` and exit 5; the same command run again resumes it.
 
 ```json
 {

--- a/docs/annotation.md
+++ b/docs/annotation.md
@@ -77,6 +77,16 @@ or state data. Optional subtask writeback has additional compatibility rules:
 follow the [LeRobot subtask tutorial](lerobot-subtasks.md) and
 [writeback compatibility guide](lerobot.md) before using `--write-lerobot`.
 
+## Read the labels
+
+```sh
+cerul status ./video.mp4 --timeline
+```
+
+This prints the published records in time order, one line each, so you can judge
+a run without opening a JSONL file. Narrow it with `--type event` and lengthen it
+with `--limit 200`. It reads sidecars only: no model call and no network.
+
 ## Find and inspect the results
 
 ```sh

--- a/examples/generate_schemas.rs
+++ b/examples/generate_schemas.rs
@@ -9,6 +9,7 @@ fn main() -> Result<()> {
     let schemas = [
         ("episode", schema::<cerul::episode::Episode>()),
         ("status", schema::<cerul::status::Status>()),
+        ("timeline", schema::<cerul::status::Timeline>()),
         (
             "annotate-result",
             schema::<cerul::annotate::pipeline::Report>(),

--- a/prompts/skill.md
+++ b/prompts/skill.md
@@ -46,10 +46,11 @@ Events on stderr:
   count and path. Only a published file is safe to read or train on.
 - `log` carries human-readable notices.
 
-When a run ends partial or cancelled, the final object carries `retry`. Run
-`retry.argv` verbatim to continue: it repeats the original invocation and changes
-only what the failure calls for. Never add `--recompute` to a retry; it discards
-finished work.
+A partial run's final object carries `retry`. Run `retry.argv` verbatim to
+continue: it repeats the original invocation and changes only what the failure
+calls for. A cancelled run has no result object at all, only
+`{"error":{"code":"cancelled",...}}` and exit 5; run the same command again to
+resume it. Never add `--recompute` to either; it discards finished work.
 
 ## Workflows
 

--- a/prompts/skill.md
+++ b/prompts/skill.md
@@ -46,11 +46,13 @@ Events on stderr:
   count and path. Only a published file is safe to read or train on.
 - `log` carries human-readable notices.
 
-A partial run's final object carries `retry`. Run `retry.argv` verbatim to
-continue: it repeats the original invocation and changes only what the failure
-calls for. A cancelled run has no result object at all, only
-`{"error":{"code":"cancelled",...}}` and exit 5; run the same command again to
-resume it. Never add `--recompute` to either; it discards finished work.
+A **partial `annotate`** carries `retry` in its final object. Run `retry.argv`
+verbatim to continue: it repeats the original invocation and changes only what
+the failure calls for. Other commands that can exit 6, such as `index` and
+`status --providers`, carry no `retry`; run the same command again, which reuses
+everything that finished. A cancelled run has no result object at all, only
+`{"error":{"code":"cancelled",...}}` and exit 5; the same command resumes it.
+Never add `--recompute` to any of these; it discards finished work.
 
 ## Workflows
 

--- a/prompts/skill.md
+++ b/prompts/skill.md
@@ -1,0 +1,118 @@
+---
+name: cerul
+description: Search local videos by meaning, exact words, or a reference image, and annotate actions, events, interactions, and states in videos or LeRobot demonstrations. Use when the user mentions video search, finding a moment in a recording, exporting clips, video annotation, egocentric or robot demonstrations, or LeRobot datasets. Requires the cerul command-line tool.
+---
+
+# Cerul
+
+Cerul turns local video into searchable, annotated data using the user's own
+model endpoints. There is no account and no server to start: run the binary and
+read its output. Sidecar files beside each video are authoritative; search
+indexes are caches that rebuild from them without model calls.
+
+## Before anything else
+
+Run `cerul --version`. If it is missing, follow the installation runbook at
+https://github.com/cerul-ai/cerul/blob/main/docs/agent-setup.md. Do not install
+Rust, Python, Ollama, or system FFmpeg for this workflow, and do not switch to a
+source build when a download fails; report the error instead.
+
+Run `cerul --json auth` to see whether a key is available. It reports whether a
+key is saved or exported, never the value. Never echo a key, print part of it,
+write it to a log or a commit, or read an unrelated project's `.env`. When no key
+is available, ask the user to run `cerul auth set` in their own terminal, or to
+export the key themselves.
+
+## Always pass --json
+
+`--json` is the machine contract, and it is the only mode to use:
+
+- stdout carries exactly one JSON object, printed when the command finishes.
+- stderr carries one JSON event per line while the command runs.
+- Nothing ever prompts. A missing argument returns `invalid_arguments`, not a
+  question.
+
+Exit codes: `0` success, `2` arguments or configuration, `3` unavailable
+dependency or capability, `4` execution failure, `5` cancelled, `6` partial
+success. Read the code as well as the output. **Exit 6 is not success**: part of
+the work finished and the rest did not.
+
+Events on stderr:
+
+- `progress` counts units of work for one station.
+- `checkpoint` marks a window that is saved and will be reused after an
+  interruption, so a rerun resumes rather than repeating it.
+- `published` marks a validated annotation file that now exists, with its record
+  count and path. Only a published file is safe to read or train on.
+- `log` carries human-readable notices.
+
+When a run ends partial or cancelled, the final object carries `retry`. Run
+`retry.argv` verbatim to continue: it repeats the original invocation and changes
+only what the failure calls for. Never add `--recompute` to a retry; it discards
+finished work.
+
+## Workflows
+
+Preview any expensive command with `--dry-run` first. It writes nothing, calls no
+model, and asks for no credential.
+
+**Search a video.** Indexing is required for search, and it sends media to the
+configured endpoints.
+
+```sh
+cerul --json --dry-run index ./video.mp4
+cerul --json index ./video.mp4
+cerul --json search "a person picking up a cup" --in ./video.mp4
+cerul --json search --text "ERROR 500"
+cerul --json search "a person picking up a cup" --save ./clips
+```
+
+Result numbers are global, so `cerul open 1` plays the first moment in the user's
+video player and `cerul open 3` plays the third. `score` is a ranking similarity, not a probability that the
+moment is the right one; do not present it as a confidence or an accuracy.
+
+**Annotate actions.** No indexing step is needed.
+
+```sh
+cerul --json --dry-run annotate ./video.mp4 --semantic subtask,event,interaction,state
+cerul --json annotate ./video.mp4 --semantic subtask,event,interaction,state
+cerul --json status ./video.mp4 --timeline
+```
+
+Ordinary videos default to `task,subtask,flag`; list the items explicitly to get
+the rest. Available items: task, subtask, event, interaction, state, flag,
+progress. Pose, depth, segmentation, and 3D trajectories are not implemented and
+must not be offered.
+
+**Annotate a LeRobot dataset.** Pass the dataset root that contains `meta/`.
+
+```sh
+cerul --json annotate ./dataset --semantic --only 0
+cerul --json status ./dataset --timeline
+```
+
+Start with one episode. Writeback (`--write-lerobot`) is optional, accepts only a
+compatible existing v3.1 dataset, and never upgrades a format; read
+https://github.com/cerul-ai/cerul/blob/main/docs/lerobot.md before using it.
+
+**Read what was produced.** `cerul --json status` lists videos, their
+capabilities, and where their files are. `cerul --json status PATH --timeline`
+returns published annotation records in time order, with `--type` and `--limit`.
+
+## Rules
+
+- Ask the user before any command that sends media to a model endpoint, and say
+  that their provider bills it. Local OCR is the exception: it runs on the CPU.
+- Do not run `status --providers` unless asked; it makes real model requests.
+- Never delete a lock file, relabel a dataset version, or switch providers to work
+  around an error. Report the error and its category.
+- Keep one `--workspace` for a whole task. Do not switch it to escape a lock.
+- Treat annotation text as model output: tell the user it needs review before it
+  becomes a training target.
+- An empty search result is a normal outcome, not a failure. Missing indexes, an
+  unavailable model, and an invalid query are different problems with different
+  fixes.
+
+## Command reference
+
+Generated from this build's argument definitions.

--- a/schemas/annotate-result.json
+++ b/schemas/annotate-result.json
@@ -39,6 +39,11 @@
         "complete": {
           "type": "boolean"
         },
+        "dataset": {
+          "description": "True when the episode came from a LeRobot dataset.",
+          "type": "boolean",
+          "default": false
+        },
         "episode": {
           "type": "string"
         },
@@ -48,10 +53,22 @@
             "null"
           ]
         },
+        "path": {
+          "description": "Where the published annotation file is, once validation and publication\nsucceeded. A checkpoint on disk is not a published file, so an incomplete\nor dry-run module has no path.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "records": {
           "type": "integer",
           "format": "uint",
           "minimum": 0
+        },
+        "source": {
+          "description": "What this result belongs to: the video file, or the dataset root when the\nepisode came from one. Episodes of a dataset share their MP4 shards, so a\nmedia file name alone cannot tell two results apart; the dataset and the\nepisode index can.",
+          "type": "string",
+          "default": ""
         },
         "stream": {
           "type": "string"

--- a/schemas/annotate-result.json
+++ b/schemas/annotate-result.json
@@ -16,6 +16,17 @@
     "partial": {
       "type": "boolean"
     },
+    "retry": {
+      "description": "Present when work remains. Absent on a complete or dry run.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Retry"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "writebacks": {
       "type": "array",
       "items": {
@@ -80,6 +91,40 @@
         "annotation",
         "records",
         "complete"
+      ]
+    },
+    "Retry": {
+      "description": "The command that continues unfinished work: the original invocation with\nonly the failure's fix applied, so running it is always safe. Published work\nis reused and nothing is recomputed on purpose.\n\nThe result carries this so that a machine reader finds recovery in the same\nobject as the failure. Only the binary can fill it in, because only the\nbinary sees an argument list.",
+      "type": "object",
+      "properties": {
+        "argv": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "reason": {
+          "$ref": "#/$defs/RetryReason"
+        }
+      },
+      "required": [
+        "argv",
+        "reason"
+      ]
+    },
+    "RetryReason": {
+      "description": "Why a run stopped early, in the terms that decide what to change about it.",
+      "oneOf": [
+        {
+          "description": "A provider limited the request rate, so the retry lowers it.",
+          "type": "string",
+          "const": "rate_limit"
+        },
+        {
+          "description": "Work remains for another reason; the retry repeats the command unchanged.",
+          "type": "string",
+          "const": "incomplete"
+        }
       ]
     },
     "WritebackResult": {

--- a/schemas/event.json
+++ b/schemas/event.json
@@ -36,6 +36,74 @@
       ]
     },
     {
+      "description": "A durable unit of work that a rerun will reuse instead of repeating.",
+      "type": "object",
+      "properties": {
+        "episode": {
+          "type": "string"
+        },
+        "event": {
+          "type": "string",
+          "const": "checkpoint"
+        },
+        "station": {
+          "type": "string"
+        },
+        "total": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
+        },
+        "window": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "event",
+        "episode",
+        "station",
+        "window",
+        "total"
+      ]
+    },
+    {
+      "description": "A validated annotation file that now exists on disk. Distinct from a\ncheckpoint: only a published module is safe to read or train on.",
+      "type": "object",
+      "properties": {
+        "annotation": {
+          "type": "string"
+        },
+        "episode": {
+          "type": "string"
+        },
+        "event": {
+          "type": "string",
+          "const": "published"
+        },
+        "path": {
+          "type": "string"
+        },
+        "records": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
+        },
+        "stream": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "event",
+        "episode",
+        "stream",
+        "annotation",
+        "records",
+        "path"
+      ]
+    },
+    {
       "type": "object",
       "properties": {
         "event": {

--- a/schemas/status.json
+++ b/schemas/status.json
@@ -88,6 +88,15 @@
             "type": "string"
           }
         },
+        "duration_us": {
+          "description": "Episode-relative length of the primary stream, read from the sidecar.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64",
+          "default": null
+        },
         "embedding_spaces": {
           "type": "array",
           "items": {

--- a/schemas/timeline.json
+++ b/schemas/timeline.json
@@ -1,0 +1,137 @@
+{
+  "$id": "https://cerul.ai/schemas/timeline/1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Timeline",
+  "type": "object",
+  "properties": {
+    "episodes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/TimelineEpisode"
+      }
+    }
+  },
+  "required": [
+    "episodes"
+  ],
+  "$defs": {
+    "Record": {
+      "type": "object",
+      "properties": {
+        "confidence": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double",
+          "default": null
+        },
+        "end_us": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "id": {
+          "type": "string"
+        },
+        "start_us": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "id",
+        "start_us",
+        "end_us"
+      ]
+    },
+    "TimelineEntry": {
+      "description": "One published annotation record, reduced to what a person reads in a list.",
+      "type": "object",
+      "properties": {
+        "annotation": {
+          "description": "Full annotation name, for example `semantic.subtask`.",
+          "type": "string"
+        },
+        "end_us": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "episode": {
+          "type": "string"
+        },
+        "record": {
+          "$ref": "#/$defs/Record"
+        },
+        "start_us": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "stream": {
+          "type": "string"
+        },
+        "summary": {
+          "description": "The record's own fields written as one line. The record itself stays\nauthoritative; this is a reading aid, not a new data format.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "episode",
+        "stream",
+        "annotation",
+        "start_us",
+        "end_us",
+        "summary",
+        "record"
+      ]
+    },
+    "TimelineEpisode": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotation names present for this episode, in file order.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "duration_us": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TimelineEntry"
+          }
+        },
+        "episode_id": {
+          "type": "string"
+        },
+        "media": {
+          "type": "string"
+        },
+        "sidecar": {
+          "type": "string"
+        },
+        "total": {
+          "description": "Records that matched the selection before `limit` was applied.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "episode_id",
+        "media",
+        "sidecar",
+        "annotations",
+        "total",
+        "entries"
+      ]
+    }
+  }
+}

--- a/scripts/check-docs.py
+++ b/scripts/check-docs.py
@@ -30,6 +30,7 @@ def documents():
         "examples",
         "models",
         "prompts",
+        "skills",
         "tests/fixtures",
         ".github",
     ):

--- a/skills/cerul/SKILL.md
+++ b/skills/cerul/SKILL.md
@@ -2,6 +2,7 @@
 name: cerul
 description: Search local videos by meaning, exact words, or a reference image, and annotate actions, events, interactions, and states in videos or LeRobot demonstrations. Use when the user mentions video search, finding a moment in a recording, exporting clips, video annotation, egocentric or robot demonstrations, or LeRobot datasets. Requires the cerul command-line tool.
 generated-by: cerul 0.0.6
+generated-sha256: e0f5e6313d19393cf8e283f595734d14c3ac64ff5fea743383ccd1367b9f1a81
 ---
 
 # Cerul
@@ -47,11 +48,13 @@ Events on stderr:
   count and path. Only a published file is safe to read or train on.
 - `log` carries human-readable notices.
 
-A partial run's final object carries `retry`. Run `retry.argv` verbatim to
-continue: it repeats the original invocation and changes only what the failure
-calls for. A cancelled run has no result object at all, only
-`{"error":{"code":"cancelled",...}}` and exit 5; run the same command again to
-resume it. Never add `--recompute` to either; it discards finished work.
+A **partial `annotate`** carries `retry` in its final object. Run `retry.argv`
+verbatim to continue: it repeats the original invocation and changes only what
+the failure calls for. Other commands that can exit 6, such as `index` and
+`status --providers`, carry no `retry`; run the same command again, which reuses
+everything that finished. A cancelled run has no result object at all, only
+`{"error":{"code":"cancelled",...}}` and exit 5; the same command resumes it.
+Never add `--recompute` to any of these; it discards finished work.
 
 ## Workflows
 

--- a/skills/cerul/SKILL.md
+++ b/skills/cerul/SKILL.md
@@ -47,10 +47,11 @@ Events on stderr:
   count and path. Only a published file is safe to read or train on.
 - `log` carries human-readable notices.
 
-When a run ends partial or cancelled, the final object carries `retry`. Run
-`retry.argv` verbatim to continue: it repeats the original invocation and changes
-only what the failure calls for. Never add `--recompute` to a retry; it discards
-finished work.
+A partial run's final object carries `retry`. Run `retry.argv` verbatim to
+continue: it repeats the original invocation and changes only what the failure
+calls for. A cancelled run has no result object at all, only
+`{"error":{"code":"cancelled",...}}` and exit 5; run the same command again to
+resume it. Never add `--recompute` to either; it discards finished work.
 
 ## Workflows
 
@@ -217,3 +218,4 @@ Print or install the agent skill that teaches this CLI to a coding agent
   --install <AGENT>           Install for this agent: claude, codex, or pi
   --dir <DIR>                 Install into this skills directory instead of an agent's own
   --print                     Write the skill to stdout instead of installing it
+  --force                     Replace an installed skill even when it was changed after it was written

--- a/skills/cerul/SKILL.md
+++ b/skills/cerul/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: cerul
+description: Search local videos by meaning, exact words, or a reference image, and annotate actions, events, interactions, and states in videos or LeRobot demonstrations. Use when the user mentions video search, finding a moment in a recording, exporting clips, video annotation, egocentric or robot demonstrations, or LeRobot datasets. Requires the cerul command-line tool.
+generated-by: cerul 0.0.6
+---
+
+# Cerul
+
+Cerul turns local video into searchable, annotated data using the user's own
+model endpoints. There is no account and no server to start: run the binary and
+read its output. Sidecar files beside each video are authoritative; search
+indexes are caches that rebuild from them without model calls.
+
+## Before anything else
+
+Run `cerul --version`. If it is missing, follow the installation runbook at
+https://github.com/cerul-ai/cerul/blob/main/docs/agent-setup.md. Do not install
+Rust, Python, Ollama, or system FFmpeg for this workflow, and do not switch to a
+source build when a download fails; report the error instead.
+
+Run `cerul --json auth` to see whether a key is available. It reports whether a
+key is saved or exported, never the value. Never echo a key, print part of it,
+write it to a log or a commit, or read an unrelated project's `.env`. When no key
+is available, ask the user to run `cerul auth set` in their own terminal, or to
+export the key themselves.
+
+## Always pass --json
+
+`--json` is the machine contract, and it is the only mode to use:
+
+- stdout carries exactly one JSON object, printed when the command finishes.
+- stderr carries one JSON event per line while the command runs.
+- Nothing ever prompts. A missing argument returns `invalid_arguments`, not a
+  question.
+
+Exit codes: `0` success, `2` arguments or configuration, `3` unavailable
+dependency or capability, `4` execution failure, `5` cancelled, `6` partial
+success. Read the code as well as the output. **Exit 6 is not success**: part of
+the work finished and the rest did not.
+
+Events on stderr:
+
+- `progress` counts units of work for one station.
+- `checkpoint` marks a window that is saved and will be reused after an
+  interruption, so a rerun resumes rather than repeating it.
+- `published` marks a validated annotation file that now exists, with its record
+  count and path. Only a published file is safe to read or train on.
+- `log` carries human-readable notices.
+
+When a run ends partial or cancelled, the final object carries `retry`. Run
+`retry.argv` verbatim to continue: it repeats the original invocation and changes
+only what the failure calls for. Never add `--recompute` to a retry; it discards
+finished work.
+
+## Workflows
+
+Preview any expensive command with `--dry-run` first. It writes nothing, calls no
+model, and asks for no credential.
+
+**Search a video.** Indexing is required for search, and it sends media to the
+configured endpoints.
+
+```sh
+cerul --json --dry-run index ./video.mp4
+cerul --json index ./video.mp4
+cerul --json search "a person picking up a cup" --in ./video.mp4
+cerul --json search --text "ERROR 500"
+cerul --json search "a person picking up a cup" --save ./clips
+```
+
+Result numbers are global, so `cerul open 1` plays the first moment in the user's
+video player and `cerul open 3` plays the third. `score` is a ranking similarity, not a probability that the
+moment is the right one; do not present it as a confidence or an accuracy.
+
+**Annotate actions.** No indexing step is needed.
+
+```sh
+cerul --json --dry-run annotate ./video.mp4 --semantic subtask,event,interaction,state
+cerul --json annotate ./video.mp4 --semantic subtask,event,interaction,state
+cerul --json status ./video.mp4 --timeline
+```
+
+Ordinary videos default to `task,subtask,flag`; list the items explicitly to get
+the rest. Available items: task, subtask, event, interaction, state, flag,
+progress. Pose, depth, segmentation, and 3D trajectories are not implemented and
+must not be offered.
+
+**Annotate a LeRobot dataset.** Pass the dataset root that contains `meta/`.
+
+```sh
+cerul --json annotate ./dataset --semantic --only 0
+cerul --json status ./dataset --timeline
+```
+
+Start with one episode. Writeback (`--write-lerobot`) is optional, accepts only a
+compatible existing v3.1 dataset, and never upgrades a format; read
+https://github.com/cerul-ai/cerul/blob/main/docs/lerobot.md before using it.
+
+**Read what was produced.** `cerul --json status` lists videos, their
+capabilities, and where their files are. `cerul --json status PATH --timeline`
+returns published annotation records in time order, with `--type` and `--limit`.
+
+## Rules
+
+- Ask the user before any command that sends media to a model endpoint, and say
+  that their provider bills it. Local OCR is the exception: it runs on the CPU.
+- Do not run `status --providers` unless asked; it makes real model requests.
+- Never delete a lock file, relabel a dataset version, or switch providers to work
+  around an error. Report the error and its category.
+- Keep one `--workspace` for a whole task. Do not switch it to escape a lock.
+- Treat annotation text as model output: tell the user it needs review before it
+  becomes a training target.
+- An empty search result is a normal outcome, not a failure. Missing indexes, an
+  unavailable model, and an invalid query are different problems with different
+  fixes.
+
+## Command reference
+
+Generated from this build's argument definitions.
+These options work on every command:
+
+  --json                      Machine-readable output: final JSON on stdout, NDJSON events on stderr
+  --workspace <DIR>           Where indexes and caches live (default ~/.cerul)
+  --dry-run                   Show what would happen without writing anything or calling models
+  --yes                       Skip confirmations and never prompt; fail instead of asking for a key
+  --quiet                     Only print errors
+  --recompute                 Redo work even when a valid result already exists
+  --set <KEY=TOML_VALUE>      Override a configuration field, for example embedding.dims=1536
+  -v                          More diagnostic output (repeatable)
+
+### cerul index
+
+Index videos so they can be searched (screen text, speech, visual search)
+
+  <PATHS>...                  Videos, directories, or LeRobot datasets
+  --no-audio                  Skip speech transcription
+  --no-ocr                    Skip screen text recognition
+  --chunk <DURATION>          Length of each searchable window, for example 30s (default 30s)
+  --overlap <DURATION>        Overlap between windows (default 5s)
+  --skip-still                Skip windows where the picture does not change
+  --streams <STREAMS>         Streams to index, comma-separated (default primary)
+  --only <ONLY>               Only these episodes (ids or local indexes), comma-separated
+  --jobs <JOBS>               Parallel model requests (default 4)
+  --rpm <RPM>                 Cap on model requests per minute
+  --sidecar-dir <DIR>         Store sidecars here instead of beside the videos
+
+### cerul search
+
+Find moments by description, exact words, or a reference image
+
+  <QUERY>                     What to look for, in plain words, wrapped in quotes
+  --image <FILE>              Search with a reference image instead of words
+  --text                      Match the exact words in screen text or speech instead of by meaning
+  --save <DIR>                Save each matching moment as an MP4 clip in this directory
+  --preview                   Show a still frame for each result (default when the terminal supports images)
+  --no-preview                Never show still frames
+  --limit <N>                 Maximum number of results (default 10)
+  --in <PATH>                 Only search videos under this path
+  --pad <DURATION>            Seconds of context added before and after each saved clip (default 2s)
+  --filter <KEY=VALUE>        Restrict by annotation field, for example semantic.event.verb=pour
+  --threshold <THRESHOLD>     Minimum similarity score for semantic matches
+  --count                     Count matching intervals instead of listing them
+
+### cerul status
+
+Show indexed videos, model configuration, and storage
+
+  <PATH>                      Only report videos under this path
+  --providers                 Verify configured model endpoints with small test requests (cached for seven days)
+  --timeline                  Read the published annotations in time order instead of the summary
+  --type <ITEM>               Only one semantic item, for example event
+  --limit <N>                 Most annotation records to show per video (default 50)
+
+### cerul open
+
+Open a result from the last search in a video player, at its moment
+
+  <NUMBER>                    Result number shown by the last search (default 1)
+
+### cerul auth
+
+Manage the saved Gemini API key
+
+  cerul auth set                   Enter and verify a Gemini API key, replacing any saved one
+  cerul auth remove                Delete the saved Gemini API key
+
+### cerul annotate
+
+Generate semantic annotations (tasks, events, states) for videos
+
+  <PATHS>...                  Videos, directories, or LeRobot datasets
+  --semantic <ITEMS>          Semantic items to generate, comma-separated (default set when no value is given)
+  --write-lerobot             Write subtask annotations back into the LeRobot dataset
+  --out <DIR>                 New output LeRobot dataset (requires --write-lerobot)
+  --ontology <FILE>           Custom ontology file
+  --window <WINDOW>           Model window length, for example 30s (default 30s)
+  --fps <FPS>                 Frames per second sampled for the model (default 2)
+  --jobs <JOBS>               Parallel model requests (default 4)
+  --rpm <RPM>                 Cap on model requests per minute
+  --streams <STREAMS>         Streams to annotate, comma-separated (default primary)
+  --only <ONLY>               Only these episodes (ids or local indexes), comma-separated
+
+### cerul remove
+
+Remove indexed videos, or free the disk they and their caches use
+
+  <PATHS>...                  Videos or directories to forget. Their files are left where they are
+  --cache                     Free cached previews, query vectors, and media proxies; all regenerated
+  --all-indexes               Free every search index; each rebuilds from sidecars with no model calls
+  --index <SPACE>             Free one search index by space id; rebuilt from sidecars on next use
+  --compact                   Reclaim space inside search indexes without dropping them
+
+### cerul skill
+
+Print or install the agent skill that teaches this CLI to a coding agent
+
+  --install <AGENT>           Install for this agent: claude, codex, or pi
+  --dir <DIR>                 Install into this skills directory instead of an agent's own
+  --print                     Write the skill to stdout instead of installing it

--- a/src/annotate/pipeline.rs
+++ b/src/annotate/pipeline.rs
@@ -406,6 +406,10 @@ async fn run_inner(
             discover::publish_episode(workspace, &episode, None)?
         };
         for stream in selected_streams {
+            // Conflicts are projected into the flag file once every module of
+            // this stream has run, so a flag module's real count is not known
+            // until then. Announcing it early would disagree with the file.
+            let mut deferred: Vec<usize> = Vec::new();
             for item in &items {
                 interrupted(&cancel)?;
                 let mut result = ModuleResult {
@@ -458,14 +462,17 @@ async fn run_inner(
                             let published =
                                 stream_directory(&sidecar, &stream, &episode.time.reference)
                                     .join(format!("semantic.{item}.jsonl"));
-                            events.emit(Event::Published {
-                                episode: episode.episode_id.clone(),
-                                stream: stream.clone(),
-                                annotation: result.annotation.clone(),
-                                records: result.records as u64,
-                                path: published.clone(),
-                            });
-                            result.path = Some(published);
+                            result.path = Some(published.clone());
+                            match item.as_str() {
+                                "flag" => deferred.push(report.modules.len()),
+                                _ => events.emit(Event::Published {
+                                    episode: episode.episode_id.clone(),
+                                    stream: stream.clone(),
+                                    annotation: result.annotation.clone(),
+                                    records: result.records as u64,
+                                    path: published,
+                                }),
+                            }
                             if options.write_lerobot
                                 && item == "subtask"
                                 && stream == episode.time.reference
@@ -499,6 +506,22 @@ async fn run_inner(
             }
             if !options.dry_run {
                 publish_conflicts(&episode, &stream, &sidecar)?;
+                // The sidecar is authoritative, so the count that is reported and
+                // announced is the one the file ended up with.
+                for index in deferred.drain(..) {
+                    let module = &mut report.modules[index];
+                    let Some(path) = module.path.clone() else {
+                        continue;
+                    };
+                    module.records = AnnotationFile::read(&path)?.records.len();
+                    events.emit(Event::Published {
+                        episode: module.episode.clone(),
+                        stream: module.stream.clone(),
+                        annotation: module.annotation.clone(),
+                        records: module.records as u64,
+                        path,
+                    });
+                }
             }
         }
     }

--- a/src/annotate/pipeline.rs
+++ b/src/annotate/pipeline.rs
@@ -106,6 +106,20 @@ pub struct ModuleResult {
     pub records: usize,
     pub complete: bool,
     pub error: Option<String>,
+    /// What this result belongs to: the video file, or the dataset root when the
+    /// episode came from one. Episodes of a dataset share their MP4 shards, so a
+    /// media file name alone cannot tell two results apart; the dataset and the
+    /// episode index can.
+    #[serde(default)]
+    pub source: PathBuf,
+    /// True when the episode came from a LeRobot dataset.
+    #[serde(default)]
+    pub dataset: bool,
+    /// Where the published annotation file is, once validation and publication
+    /// succeeded. A checkpoint on disk is not a published file, so an incomplete
+    /// or dry-run module has no path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
 }
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct WritebackResult {
@@ -376,6 +390,19 @@ async fn run_inner(
                     records: 0,
                     complete: false,
                     error: None,
+                    source: match dataset {
+                        true => episode.source.root.clone(),
+                        false => episode
+                            .video(&episode.time.reference)
+                            .ok()
+                            .and_then(|stream| match stream {
+                                crate::episode::Stream::Video { path, .. } => Some(path.clone()),
+                                _ => None,
+                            })
+                            .unwrap_or_else(|| episode.source.root.clone()),
+                    },
+                    dataset,
+                    path: None,
                 };
                 if !options.dry_run {
                     match semantic::run(
@@ -398,6 +425,17 @@ async fn run_inner(
                         Ok(product) => {
                             result.complete = true;
                             result.records = product.annotation.records.len();
+                            let published =
+                                stream_directory(&sidecar, &stream, &episode.time.reference)
+                                    .join(format!("semantic.{item}.jsonl"));
+                            events.emit(Event::Published {
+                                episode: episode.episode_id.clone(),
+                                stream: stream.clone(),
+                                annotation: result.annotation.clone(),
+                                records: result.records as u64,
+                                path: published.clone(),
+                            });
+                            result.path = Some(published);
                             if options.write_lerobot
                                 && item == "subtask"
                                 && stream == episode.time.reference

--- a/src/annotate/pipeline.rs
+++ b/src/annotate/pipeline.rs
@@ -128,12 +128,36 @@ pub struct WritebackResult {
     pub complete: bool,
     pub error: Option<String>,
 }
+/// Why a run stopped early, in the terms that decide what to change about it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryReason {
+    /// A provider limited the request rate, so the retry lowers it.
+    RateLimit,
+    /// Work remains for another reason; the retry repeats the command unchanged.
+    Incomplete,
+}
+/// The command that continues unfinished work: the original invocation with
+/// only the failure's fix applied, so running it is always safe. Published work
+/// is reused and nothing is recomputed on purpose.
+///
+/// The result carries this so that a machine reader finds recovery in the same
+/// object as the failure. Only the binary can fill it in, because only the
+/// binary sees an argument list.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct Retry {
+    pub argv: Vec<String>,
+    pub reason: RetryReason,
+}
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Report {
     pub modules: Vec<ModuleResult>,
     pub writebacks: Vec<WritebackResult>,
     pub partial: bool,
     pub dry_run: bool,
+    /// Present when work remains. Absent on a complete or dry run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry: Option<Retry>,
 }
 fn interrupted(cancel: &CancellationToken) -> Result<()> {
     if cancel.is_cancelled() {
@@ -359,6 +383,7 @@ async fn run_inner(
         writebacks: Vec::new(),
         partial: false,
         dry_run: options.dry_run,
+        retry: None,
     };
     for episode in episodes {
         let dataset = episode.source.format.starts_with("lerobot/");
@@ -390,13 +415,18 @@ async fn run_inner(
                     records: 0,
                     complete: false,
                     error: None,
+                    // Stream paths are relative to the episode's root, and two
+                    // directories can hold the same file name, so the root has to
+                    // stay on the front of it.
                     source: match dataset {
                         true => episode.source.root.clone(),
                         false => episode
                             .video(&episode.time.reference)
                             .ok()
                             .and_then(|stream| match stream {
-                                crate::episode::Stream::Video { path, .. } => Some(path.clone()),
+                                crate::episode::Stream::Video { path, .. } => {
+                                    Some(episode.source.root.join(path))
+                                }
                                 _ => None,
                             })
                             .unwrap_or_else(|| episode.source.root.clone()),

--- a/src/annotate/semantic.rs
+++ b/src/annotate/semantic.rs
@@ -314,6 +314,14 @@ pub async fn run(
         normalize(item, &unit, &header, &pts, ontology)?;
         checkpoints.save(&unit_key, &unit)?;
         units.push(unit);
+        // Saved before the counter moves, so a reader can trust that this window
+        // survives an interruption and will be reused rather than re-requested.
+        events.emit(Event::Checkpoint {
+            episode: episode.episode_id.clone(),
+            station: name.clone(),
+            window: index as u64 + 1,
+            total: windows.len() as u64,
+        });
         events.emit(Event::Progress {
             episode: episode.episode_id.clone(),
             station: name.clone(),

--- a/src/documentation_tests.rs
+++ b/src/documentation_tests.rs
@@ -51,10 +51,12 @@ fn the_retry_repeats_the_invocation_and_changes_only_the_rate() {
         limited.reason,
         cerul::annotate::pipeline::RetryReason::RateLimit
     );
+    // The program is repeated as it was invoked: a path was probably used
+    // because the binary is not on PATH, so shortening it breaks the copy.
     assert_eq!(
         limited.argv,
         [
-            "cerul",
+            "/usr/local/bin/cerul",
             "annotate",
             "/my videos/demo.mp4",
             "--semantic",
@@ -66,7 +68,7 @@ fn the_retry_repeats_the_invocation_and_changes_only_the_rate() {
     // Quoting is what makes the printed command survive a copy into a shell.
     assert_eq!(
         crate::render::shell_command(&limited.argv),
-        "cerul annotate '/my videos/demo.mp4' --semantic subtask,event --rpm 6"
+        "/usr/local/bin/cerul annotate '/my videos/demo.mp4' --semantic subtask,event --rpm 6"
     );
     // Nothing else earns a rate cap, and no failure earns --recompute.
     let other = stopped("connection reset");

--- a/src/documentation_tests.rs
+++ b/src/documentation_tests.rs
@@ -11,7 +11,7 @@ struct Example {
     args: Vec<String>,
 }
 
-fn stopped(error: &str) -> super::Retry {
+fn stopped(error: &str) -> cerul::annotate::pipeline::Retry {
     let report = cerul::annotate::pipeline::Report {
         modules: vec![cerul::annotate::pipeline::ModuleResult {
             episode: "demo/0".into(),
@@ -27,6 +27,7 @@ fn stopped(error: &str) -> super::Retry {
         writebacks: Vec::new(),
         partial: true,
         dry_run: false,
+        retry: None,
     };
     let original: Vec<String> = [
         "/usr/local/bin/cerul",
@@ -46,7 +47,10 @@ fn stopped(error: &str) -> super::Retry {
 #[test]
 fn the_retry_repeats_the_invocation_and_changes_only_the_rate() {
     let limited = stopped("gemini rate limit (429)");
-    assert_eq!(limited.reason, "rate_limit");
+    assert_eq!(
+        limited.reason,
+        cerul::annotate::pipeline::RetryReason::RateLimit
+    );
     assert_eq!(
         limited.argv,
         [
@@ -66,7 +70,10 @@ fn the_retry_repeats_the_invocation_and_changes_only_the_rate() {
     );
     // Nothing else earns a rate cap, and no failure earns --recompute.
     let other = stopped("connection reset");
-    assert_eq!(other.reason, "incomplete");
+    assert_eq!(
+        other.reason,
+        cerul::annotate::pipeline::RetryReason::Incomplete
+    );
     assert!(!other.argv.iter().any(|argument| argument == "--rpm"));
     assert!(!other.argv.iter().any(|argument| argument == "--recompute"));
 }

--- a/src/documentation_tests.rs
+++ b/src/documentation_tests.rs
@@ -11,6 +11,86 @@ struct Example {
     args: Vec<String>,
 }
 
+fn stopped(error: &str) -> super::Retry {
+    let report = cerul::annotate::pipeline::Report {
+        modules: vec![cerul::annotate::pipeline::ModuleResult {
+            episode: "demo/0".into(),
+            stream: "primary".into(),
+            annotation: "semantic.event".into(),
+            records: 0,
+            complete: false,
+            error: Some(error.to_owned()),
+            source: std::path::PathBuf::from("/my videos/demo.mp4"),
+            dataset: false,
+            path: None,
+        }],
+        writebacks: Vec::new(),
+        partial: true,
+        dry_run: false,
+    };
+    let original: Vec<String> = [
+        "/usr/local/bin/cerul",
+        "annotate",
+        "/my videos/demo.mp4",
+        "--semantic",
+        "subtask,event",
+    ]
+    .iter()
+    .map(|argument| (*argument).to_owned())
+    .collect();
+    super::retry_after(&report, &original).expect("a partial run offers a retry")
+}
+
+/// The retry has to be the same run again, or it is not a retry: same paths, same
+/// labels, with only the limit the provider asked for.
+#[test]
+fn the_retry_repeats_the_invocation_and_changes_only_the_rate() {
+    let limited = stopped("gemini rate limit (429)");
+    assert_eq!(limited.reason, "rate_limit");
+    assert_eq!(
+        limited.argv,
+        [
+            "cerul",
+            "annotate",
+            "/my videos/demo.mp4",
+            "--semantic",
+            "subtask,event",
+            "--rpm",
+            "6"
+        ]
+    );
+    // Quoting is what makes the printed command survive a copy into a shell.
+    assert_eq!(
+        crate::render::shell_command(&limited.argv),
+        "cerul annotate '/my videos/demo.mp4' --semantic subtask,event --rpm 6"
+    );
+    // Nothing else earns a rate cap, and no failure earns --recompute.
+    let other = stopped("connection reset");
+    assert_eq!(other.reason, "incomplete");
+    assert!(!other.argv.iter().any(|argument| argument == "--rpm"));
+    assert!(!other.argv.iter().any(|argument| argument == "--recompute"));
+}
+
+/// The committed skill and the one this build installs have to be the same file:
+/// somebody reading it on GitHub is being told how this version behaves.
+#[test]
+fn the_published_skill_matches_what_this_build_installs() {
+    let committed = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("skills/cerul/SKILL.md"),
+    )
+    .expect("skills/cerul/SKILL.md is part of the repository");
+    assert_eq!(
+        committed,
+        super::skill_text(),
+        "run `cerul skill --print > skills/cerul/SKILL.md` after changing commands or prompts/skill.md"
+    );
+    assert!(
+        committed.starts_with("---\nname: cerul\n"),
+        "skill needs front matter"
+    );
+    assert!(committed.contains(super::SKILL_MARKER));
+}
+
 #[test]
 fn public_command_examples_match_cli() {
     let output = std::process::Command::new("python3")

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,5 +1,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "event", rename_all = "snake_case")]
@@ -9,6 +10,22 @@ pub enum Event {
         station: String,
         done: u64,
         total: u64,
+    },
+    /// A durable unit of work that a rerun will reuse instead of repeating.
+    Checkpoint {
+        episode: String,
+        station: String,
+        window: u64,
+        total: u64,
+    },
+    /// A validated annotation file that now exists on disk. Distinct from a
+    /// checkpoint: only a published module is safe to read or train on.
+    Published {
+        episode: String,
+        stream: String,
+        annotation: String,
+        records: u64,
+        path: PathBuf,
     },
     Log {
         level: String,

--- a/src/guide.rs
+++ b/src/guide.rs
@@ -237,11 +237,16 @@ fn pick_input(palette: &Palette, title: &str) -> io::Result<Option<String>> {
 }
 
 /// Turns answers into the command that runs them, shown before it runs so the
-/// next run can be typed instead of answered.
-fn confirm(palette: &Palette, argv: &[String]) -> io::Result<Option<bool>> {
+/// next run can be typed instead of answered. `typed` is everything the person
+/// already wrote, so a global flag they chose appears in the command too.
+fn confirm(palette: &Palette, typed: &[String], extra: &[String]) -> io::Result<Option<bool>> {
     let term = Term::stderr();
+    let argv: Vec<String> = std::iter::once("cerul".to_owned())
+        .chain(typed.iter().cloned())
+        .chain(extra.iter().cloned())
+        .collect();
     term.write_line("")?;
-    term.write_line(&format!("  {}", palette.cmd(&render::shell_command(argv))))?;
+    term.write_line(&format!("  {}", palette.cmd(&render::shell_command(&argv))))?;
     let choices = [
         Choice::new("Start", "", Some(false)),
         Choice::new(
@@ -252,6 +257,23 @@ fn confirm(palette: &Palette, argv: &[String]) -> io::Result<Option<bool>> {
         Choice::new("Cancel", "", None),
     ];
     Ok(select(palette, "Ready", &choices)?.flatten())
+}
+
+/// Where an invocation came from, which decides how much of it may be missing.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Entry {
+    /// Typed at a prompt. Only a bare `cerul <command>` is completed, so a
+    /// half-written command still gets the parser's own error.
+    Typed,
+    /// Composed by the home menu, which appends a command to what was typed and
+    /// so may carry the global flags that came with it.
+    Menu,
+}
+
+/// Whether a person could be asked something here: one at the keyboard, one
+/// reading the screen, and no flag that means an answer was already given.
+pub fn asks(arguments: &[OsString]) -> bool {
+    !machine_facing(arguments) && interactive()
 }
 
 /// What guidance did with an invocation.
@@ -267,13 +289,30 @@ pub enum Guided {
 /// Fills in what a bare command left out, or leaves the arguments alone. The
 /// result is parsed by the ordinary parser, so nothing here can invent
 /// behaviour the command line cannot express.
-pub fn complete(arguments: Vec<OsString>, palette: &Palette) -> Guided {
-    if machine_facing(&arguments) || !interactive() || arguments.len() != 2 {
+pub fn complete(arguments: Vec<OsString>, palette: &Palette, entry: Entry) -> Guided {
+    // Only a command with nothing after it is under-specified in a way guidance
+    // can fix. A menu adds its command to flags that were already typed, so its
+    // invocation is longer without being any less bare.
+    let bare = match entry {
+        Entry::Typed => arguments.len() == 2,
+        Entry::Menu => true,
+    };
+    if !bare || !asks(&arguments) {
         return Guided::Untouched;
     }
-    let extra = match arguments[1].to_string_lossy().as_ref() {
-        "annotate" => annotate(palette),
-        "index" => index(palette),
+    let Some(command) = arguments.last() else {
+        return Guided::Untouched;
+    };
+    // Everything already typed, so the command a screen shows is the command
+    // that runs: a global flag chosen before the subcommand belongs in it.
+    let typed: Vec<String> = arguments
+        .iter()
+        .skip(1)
+        .map(|argument| argument.to_string_lossy().into_owned())
+        .collect();
+    let extra = match command.to_string_lossy().as_ref() {
+        "annotate" => annotate(palette, &typed),
+        "index" => index(palette, &typed),
         "search" => search(palette),
         _ => return Guided::Untouched,
     };
@@ -353,7 +392,7 @@ fn lerobot_scope(palette: &Palette, episodes: &[cerul::episode::Episode]) -> Opt
 
 /// What a person has in front of them, named the way they would describe it
 /// rather than by the label names the flag happens to use.
-fn annotate(palette: &Palette) -> Option<Vec<String>> {
+fn annotate(palette: &Palette, typed: &[String]) -> Option<Vec<String>> {
     let path = pick_input(palette, "Annotate · which video or dataset?").ok()??;
     let episodes = dataset(&path);
     let robot = Choice::new(
@@ -381,27 +420,23 @@ fn annotate(palette: &Palette) -> Option<Vec<String>> {
         false => [robot, general, everything],
     };
     let items = select(palette, "What is in it?", &presets).ok()??;
-    let mut argv = vec!["cerul".into(), "annotate".into(), path, "--semantic".into()];
+    let mut extra = vec![path, "--semantic".to_owned()];
     if items != "default" {
-        argv.push(items.to_owned());
+        extra.push(items.to_owned());
     }
     if let Some(episodes) = &episodes {
-        argv.extend(lerobot_scope(palette, episodes)?);
+        extra.extend(lerobot_scope(palette, episodes)?);
     }
-    let dry = confirm(palette, &argv).ok()??;
-    let mut extra: Vec<String> = argv.split_off(2);
-    if dry {
+    if confirm(palette, typed, &extra).ok()?? {
         extra.push("--dry-run".into());
     }
     Some(extra)
 }
 
-fn index(palette: &Palette) -> Option<Vec<String>> {
+fn index(palette: &Palette, typed: &[String]) -> Option<Vec<String>> {
     let path = pick_input(palette, "Index · which video or folder?").ok()??;
-    let mut argv = vec!["cerul".into(), "index".into(), path];
-    let dry = confirm(palette, &argv).ok()??;
-    let mut extra: Vec<String> = argv.split_off(2);
-    if dry {
+    let mut extra = vec![path];
+    if confirm(palette, typed, &extra).ok()?? {
         extra.push("--dry-run".into());
     }
     Some(extra)
@@ -419,9 +454,10 @@ fn search(palette: &Palette) -> Option<Vec<String>> {
 }
 
 /// Offered under the home screen, so running `cerul` still shows what it always
-/// showed and the menu is an addition rather than a replacement.
-pub fn home_menu(palette: &Palette) -> Option<Vec<OsString>> {
-    if !interactive() {
+/// showed and the menu is an addition rather than a replacement. The choice is
+/// appended to what was typed, so `--workspace` and the rest survive it.
+pub fn home_menu(palette: &Palette, arguments: &[OsString]) -> Option<Vec<OsString>> {
+    if !asks(arguments) {
         return None;
     }
     let choices = [
@@ -435,5 +471,7 @@ pub fn home_menu(palette: &Palette) -> Option<Vec<OsString>> {
         Choice::new("Leave", "", None),
     ];
     let command = select(palette, "What do you want to do?", &choices).ok()??;
-    Some(vec!["cerul".into(), OsString::from(command?)])
+    let mut next = arguments.to_vec();
+    next.push(OsString::from(command?));
+    Some(next)
 }

--- a/src/guide.rs
+++ b/src/guide.rs
@@ -400,7 +400,13 @@ fn annotate(palette: &Palette, typed: &[String]) -> Option<Vec<String>> {
         "subtask, event, interaction, state",
         "subtask,event,interaction,state",
     );
-    let general = Choice::new("A general video", "task, subtask, flag", "default");
+    // Naming the labels rather than leaning on the default: a dataset's own
+    // default is all seven types, which is not what this choice promises.
+    let general = Choice::new(
+        "A general video",
+        "task, subtask, flag",
+        "task,subtask,flag",
+    );
     let everything = Choice::new(
         "Everything",
         "all seven semantic types",

--- a/src/guide.rs
+++ b/src/guide.rs
@@ -6,7 +6,7 @@
 //! run. Guidance appears only when a person is at both ends of the process.
 //! Everything it draws goes to stderr, leaving results on stdout alone.
 use crate::render::{self, Palette};
-use console::{Key, Term, measure_text_width};
+use console::{Key, Term, measure_text_width, truncate_str};
 use std::{
     ffi::OsString,
     fs,
@@ -74,54 +74,13 @@ pub fn select<T: Clone>(
         return Ok(None);
     }
     let term = Term::stderr();
-    let width = choices
-        .iter()
-        .map(|choice| measure_text_width(&choice.label))
-        .max()
-        .unwrap_or(0);
-    let mut cursor = 0usize;
-    let mut drawn = 0usize;
     term.hide_cursor()?;
-    let chosen = loop {
-        if drawn > 0 {
-            term.clear_last_lines(drawn)?;
-        }
-        term.write_line(&palette.bold(title))?;
-        for (index, choice) in choices.iter().enumerate() {
-            let here = index == cursor;
-            let pad = " ".repeat(width - measure_text_width(&choice.label) + 3);
-            let label = if here {
-                palette.bold(&choice.label)
-            } else {
-                choice.label.clone()
-            };
-            let note = if choice.note.is_empty() {
-                String::new()
-            } else {
-                format!("{pad}{}", palette.dim(&choice.note))
-            };
-            term.write_line(&format!(
-                "{} {label}{note}",
-                if here { palette.cmd("❯") } else { " ".into() }
-            ))?;
-        }
-        term.write_line(&palette.dim("↑↓ move · Enter select · Esc leave"))?;
-        drawn = choices.len() + 2;
-        match term.read_key() {
-            Ok(Key::ArrowUp) => cursor = cursor.checked_sub(1).unwrap_or(choices.len() - 1),
-            Ok(Key::ArrowDown) => cursor = (cursor + 1) % choices.len(),
-            Ok(Key::Enter) => break Some(cursor),
-            Ok(Key::Escape) | Ok(Key::CtrlC) => break None,
-            // A terminal that cannot report keys cannot run a menu either.
-            Err(error) if error.kind() == io::ErrorKind::Interrupted => break None,
-            Err(_) => break None,
-            _ => {}
-        }
-    };
-    term.clear_last_lines(drawn)?;
+    // Whatever happens inside, the cursor comes back: a terminal left without
+    // one outlives this process and there is no undo for it.
+    let chosen = run_menu(&term, palette, title, choices);
     term.show_cursor()?;
-    // What was asked and what was answered stay on screen; the list does not.
-    match chosen {
+    match chosen? {
+        // What was asked and what was answered stay on screen; the list does not.
         Some(index) => {
             term.write_line(&format!(
                 "{} {}",
@@ -132,6 +91,61 @@ pub fn select<T: Clone>(
         }
         None => Ok(None),
     }
+}
+
+fn run_menu<T>(
+    term: &Term,
+    palette: &Palette,
+    title: &str,
+    choices: &[Choice<T>],
+) -> io::Result<Option<usize>> {
+    let width = choices
+        .iter()
+        .map(|choice| measure_text_width(&choice.label))
+        .max()
+        .unwrap_or(0);
+    let mut cursor = 0usize;
+    let mut drawn = 0usize;
+    let chosen = loop {
+        if drawn > 0 {
+            term.clear_last_lines(drawn)?;
+        }
+        // A line that wraps is two lines to the terminal and one to this loop,
+        // which would clear the wrong rows on the next redraw.
+        let columns = (term.size().1 as usize).max(20);
+        let line = |text: &str| term.write_line(truncate_str(text, columns - 1, "…").as_ref());
+        line(&palette.bold(title))?;
+        for (index, choice) in choices.iter().enumerate() {
+            let here = index == cursor;
+            let pad = " ".repeat(width - measure_text_width(&choice.label) + 3);
+            let label = match here {
+                true => palette.bold(&choice.label),
+                false => choice.label.clone(),
+            };
+            let note = match choice.note.is_empty() {
+                true => String::new(),
+                false => format!("{pad}{}", palette.dim(&choice.note)),
+            };
+            line(&format!(
+                "{} {label}{note}",
+                if here { palette.cmd("❯") } else { " ".into() }
+            ))?;
+        }
+        line(&palette.dim("↑↓ move · Enter select · Esc leave"))?;
+        drawn = choices.len() + 2;
+        match term.read_key() {
+            Ok(Key::ArrowUp) => cursor = cursor.checked_sub(1).unwrap_or(choices.len() - 1),
+            Ok(Key::ArrowDown) => cursor = (cursor + 1) % choices.len(),
+            Ok(Key::Enter) => break Some(cursor),
+            // Leaving is a normal answer, and so is a terminal that cannot
+            // report keys at all: both mean this menu asked for nothing.
+            Ok(Key::Escape) | Ok(Key::CtrlC) => break None,
+            Err(_) => break None,
+            _ => {}
+        }
+    };
+    term.clear_last_lines(drawn)?;
+    Ok(chosen)
 }
 
 /// One typed line. An empty answer means the person changed their mind.

--- a/src/guide.rs
+++ b/src/guide.rs
@@ -1,0 +1,425 @@
+//! Lightweight guidance for an under-specified command.
+//!
+//! Nothing here decides what a command does. Each screen only completes the
+//! arguments a person did not type, and the completed argument list then goes
+//! through the ordinary parser, so a guided run and a typed one are the same
+//! run. Guidance appears only when a person is at both ends of the process.
+//! Everything it draws goes to stderr, leaving results on stdout alone.
+use crate::render::{self, Palette};
+use console::{Key, Term, measure_text_width};
+use std::{
+    ffi::OsString,
+    fs,
+    io::{self, IsTerminal},
+    path::{Path, PathBuf},
+};
+
+/// Extensions the discovery step accepts. Listing anything else would offer a
+/// choice that fails as soon as it is made.
+const VIDEO: &[&str] = &[
+    "mp4", "mov", "mkv", "webm", "avi", "m4v", "mpeg", "mpg", "mts", "m2ts",
+];
+/// Enough choices to see the directory, few enough to read without scrolling.
+const LISTED: usize = 12;
+
+/// Flags that mean a machine is reading, or that an answer was already given.
+/// Their presence rules out every prompt, whatever else was typed.
+fn machine_facing(arguments: &[OsString]) -> bool {
+    arguments.iter().any(|argument| {
+        matches!(
+            argument.to_string_lossy().as_ref(),
+            "--json"
+                | "--yes"
+                | "-y"
+                | "--quiet"
+                | "-q"
+                | "--dry-run"
+                | "--help"
+                | "-h"
+                | "--version"
+                | "-V"
+        )
+    })
+}
+
+/// A person is here when both the keys they press and the screen they read
+/// belong to a terminal.
+fn interactive() -> bool {
+    io::stdin().is_terminal() && io::stderr().is_terminal()
+}
+
+pub struct Choice<T> {
+    pub label: String,
+    pub note: String,
+    pub value: T,
+}
+impl<T> Choice<T> {
+    pub fn new(label: impl Into<String>, note: impl Into<String>, value: T) -> Self {
+        Self {
+            label: label.into(),
+            note: note.into(),
+            value,
+        }
+    }
+}
+
+/// Arrow keys over a short list. Returns `None` when the person leaves, which
+/// is a normal outcome and never an error.
+pub fn select<T: Clone>(
+    palette: &Palette,
+    title: &str,
+    choices: &[Choice<T>],
+) -> io::Result<Option<T>> {
+    if choices.is_empty() {
+        return Ok(None);
+    }
+    let term = Term::stderr();
+    let width = choices
+        .iter()
+        .map(|choice| measure_text_width(&choice.label))
+        .max()
+        .unwrap_or(0);
+    let mut cursor = 0usize;
+    let mut drawn = 0usize;
+    term.hide_cursor()?;
+    let chosen = loop {
+        if drawn > 0 {
+            term.clear_last_lines(drawn)?;
+        }
+        term.write_line(&palette.bold(title))?;
+        for (index, choice) in choices.iter().enumerate() {
+            let here = index == cursor;
+            let pad = " ".repeat(width - measure_text_width(&choice.label) + 3);
+            let label = if here {
+                palette.bold(&choice.label)
+            } else {
+                choice.label.clone()
+            };
+            let note = if choice.note.is_empty() {
+                String::new()
+            } else {
+                format!("{pad}{}", palette.dim(&choice.note))
+            };
+            term.write_line(&format!(
+                "{} {label}{note}",
+                if here { palette.cmd("❯") } else { " ".into() }
+            ))?;
+        }
+        term.write_line(&palette.dim("↑↓ move · Enter select · Esc leave"))?;
+        drawn = choices.len() + 2;
+        match term.read_key() {
+            Ok(Key::ArrowUp) => cursor = cursor.checked_sub(1).unwrap_or(choices.len() - 1),
+            Ok(Key::ArrowDown) => cursor = (cursor + 1) % choices.len(),
+            Ok(Key::Enter) => break Some(cursor),
+            Ok(Key::Escape) | Ok(Key::CtrlC) => break None,
+            // A terminal that cannot report keys cannot run a menu either.
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => break None,
+            Err(_) => break None,
+            _ => {}
+        }
+    };
+    term.clear_last_lines(drawn)?;
+    term.show_cursor()?;
+    // What was asked and what was answered stay on screen; the list does not.
+    match chosen {
+        Some(index) => {
+            term.write_line(&format!(
+                "{} {}",
+                palette.dim(title),
+                palette.bold(&choices[index].label)
+            ))?;
+            Ok(Some(choices[index].value.clone()))
+        }
+        None => Ok(None),
+    }
+}
+
+/// One typed line. An empty answer means the person changed their mind.
+pub fn input(palette: &Palette, title: &str, note: &str) -> io::Result<Option<String>> {
+    let term = Term::stderr();
+    term.write_line(&palette.bold(title))?;
+    if !note.is_empty() {
+        term.write_line(&palette.dim(note))?;
+    }
+    let answer = match term.read_line() {
+        Ok(answer) => answer,
+        Err(error) if error.kind() == io::ErrorKind::Interrupted => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let answer = answer.trim().to_owned();
+    Ok((!answer.is_empty()).then_some(answer))
+}
+
+/// Videos and datasets in one directory, newest first. The current directory
+/// only: walking a tree would offer choices from somewhere the person is not.
+fn candidates(directory: &Path) -> Vec<(PathBuf, String)> {
+    let Ok(entries) = fs::read_dir(directory) else {
+        return Vec::new();
+    };
+    let mut found: Vec<(std::time::SystemTime, PathBuf, String)> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        let modified = metadata.modified().unwrap_or(std::time::UNIX_EPOCH);
+        if metadata.is_dir() {
+            // A LeRobot dataset is a directory with a meta/ directory in it.
+            if path.join("meta").is_dir() {
+                found.push((modified, path, "LeRobot dataset".into()));
+            }
+            continue;
+        }
+        let extension = path
+            .extension()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default()
+            .to_lowercase();
+        if VIDEO.contains(&extension.as_str()) {
+            let bytes = metadata.len() as f64;
+            let size = if bytes >= 1_048_576. {
+                format!("{:.0} MB", bytes / 1_048_576.)
+            } else {
+                format!("{:.0} KB", bytes / 1024.)
+            };
+            found.push((modified, path, size));
+        }
+    }
+    found.sort_by_key(|(modified, _, _)| std::cmp::Reverse(*modified));
+    found.truncate(LISTED);
+    found
+        .into_iter()
+        .map(|(_, path, note)| (path, note))
+        .collect()
+}
+
+/// Which video or dataset to work on: the files that are here, or a typed path.
+fn pick_input(palette: &Palette, title: &str) -> io::Result<Option<String>> {
+    let directory = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let found = candidates(&directory);
+    if found.is_empty() {
+        return input(
+            palette,
+            title,
+            "No video or dataset in this directory. Type a path, or press Enter to leave.",
+        );
+    }
+    let mut choices: Vec<Choice<Option<String>>> = found
+        .iter()
+        .map(|(path, note)| {
+            Choice::new(
+                format!("./{}", render::file_name(path)),
+                note.clone(),
+                Some(format!("./{}", render::file_name(path))),
+            )
+        })
+        .collect();
+    choices.push(Choice::new("Type a path…", "somewhere else", None));
+    match select(palette, title, &choices)? {
+        Some(Some(path)) => Ok(Some(path)),
+        Some(None) => input(palette, "Path to a video, folder, or dataset", ""),
+        None => Ok(None),
+    }
+}
+
+/// Turns answers into the command that runs them, shown before it runs so the
+/// next run can be typed instead of answered.
+fn confirm(palette: &Palette, argv: &[String]) -> io::Result<Option<bool>> {
+    let term = Term::stderr();
+    term.write_line("")?;
+    term.write_line(&format!("  {}", palette.cmd(&render::shell_command(argv))))?;
+    let choices = [
+        Choice::new("Start", "", Some(false)),
+        Choice::new(
+            "Preview only",
+            "--dry-run: no writes, no model calls",
+            Some(true),
+        ),
+        Choice::new("Cancel", "", None),
+    ];
+    Ok(select(palette, "Ready", &choices)?.flatten())
+}
+
+/// What guidance did with an invocation.
+pub enum Guided {
+    /// The arguments a person answered their way to.
+    Completed(Vec<OsString>),
+    /// Nothing to ask: a complete command, a machine reading, or no terminal.
+    Untouched,
+    /// The person left. Nothing was asked for, so nothing should happen.
+    Left,
+}
+
+/// Fills in what a bare command left out, or leaves the arguments alone. The
+/// result is parsed by the ordinary parser, so nothing here can invent
+/// behaviour the command line cannot express.
+pub fn complete(arguments: Vec<OsString>, palette: &Palette) -> Guided {
+    if machine_facing(&arguments) || !interactive() || arguments.len() != 2 {
+        return Guided::Untouched;
+    }
+    let extra = match arguments[1].to_string_lossy().as_ref() {
+        "annotate" => annotate(palette),
+        "index" => index(palette),
+        "search" => search(palette),
+        _ => return Guided::Untouched,
+    };
+    match extra {
+        Some(extra) => {
+            let mut completed = arguments;
+            completed.extend(extra.into_iter().map(OsString::from));
+            Guided::Completed(completed)
+        }
+        // Backing out of a question is an answer: it means no command at all,
+        // not the usage error a bare command would otherwise print.
+        None => Guided::Left,
+    }
+}
+
+/// Real episode indices and camera keys, or nothing when the dataset cannot be
+/// read. A dataset this build does not support should fail in the run, with its
+/// own error, rather than be hidden behind a menu that cannot offer anything.
+fn dataset(path: &str) -> Option<Vec<cerul::episode::Episode>> {
+    let root = Path::new(path);
+    if !root.join("meta/info.json").is_file() {
+        return None;
+    }
+    cerul::lerobot::read(root).ok().filter(|e| !e.is_empty())
+}
+
+/// Which episode and which cameras, from what the dataset actually contains.
+fn lerobot_scope(palette: &Palette, episodes: &[cerul::episode::Episode]) -> Option<Vec<String>> {
+    let mut argv = Vec::new();
+    // Indexes are not always consecutive and do not always start at zero, so the
+    // first one has to come from the dataset rather than from an assumption.
+    let first = episodes.first()?.local_id.clone();
+    let scope = [
+        Choice::new(
+            format!("Episode {first} only"),
+            "start small: one episode is one set of model calls",
+            Some(first.clone()),
+        ),
+        Choice::new(
+            format!("All {} episodes", episodes.len()),
+            "every episode in the dataset",
+            None,
+        ),
+    ];
+    if let Some(only) = select(palette, "Which episodes?", &scope).ok()?? {
+        argv.push("--only".to_owned());
+        argv.push(only);
+    }
+    let cameras: Vec<&str> = episodes
+        .first()
+        .map(|episode| {
+            episode
+                .streams
+                .iter()
+                .filter(|stream| matches!(stream, cerul::episode::Stream::Video { .. }))
+                .map(|stream| stream.id())
+                .collect()
+        })
+        .unwrap_or_default();
+    if cameras.len() > 1 {
+        let primary = &episodes.first()?.time.reference;
+        let choices = [
+            Choice::new(format!("Primary camera ({primary})"), "", false),
+            Choice::new(
+                format!("All {} cameras", cameras.len()),
+                "one set of results per camera",
+                true,
+            ),
+        ];
+        if select(palette, "Which cameras?", &choices).ok()?? {
+            argv.push("--streams".to_owned());
+            argv.push("all".to_owned());
+        }
+    }
+    Some(argv)
+}
+
+/// What a person has in front of them, named the way they would describe it
+/// rather than by the label names the flag happens to use.
+fn annotate(palette: &Palette) -> Option<Vec<String>> {
+    let path = pick_input(palette, "Annotate · which video or dataset?").ok()??;
+    let episodes = dataset(&path);
+    let robot = Choice::new(
+        "A robot or first-person demonstration",
+        "subtask, event, interaction, state",
+        "subtask,event,interaction,state",
+    );
+    let general = Choice::new("A general video", "task, subtask, flag", "default");
+    let everything = Choice::new(
+        "Everything",
+        "all seven semantic types",
+        "task,subtask,event,interaction,state,flag,progress",
+    );
+    // A dataset's own default is every semantic type, so that choice leads here.
+    let presets = match episodes.is_some() {
+        true => [
+            Choice::new(
+                "Everything",
+                "the LeRobot default: all seven types",
+                "default",
+            ),
+            robot,
+            general,
+        ],
+        false => [robot, general, everything],
+    };
+    let items = select(palette, "What is in it?", &presets).ok()??;
+    let mut argv = vec!["cerul".into(), "annotate".into(), path, "--semantic".into()];
+    if items != "default" {
+        argv.push(items.to_owned());
+    }
+    if let Some(episodes) = &episodes {
+        argv.extend(lerobot_scope(palette, episodes)?);
+    }
+    let dry = confirm(palette, &argv).ok()??;
+    let mut extra: Vec<String> = argv.split_off(2);
+    if dry {
+        extra.push("--dry-run".into());
+    }
+    Some(extra)
+}
+
+fn index(palette: &Palette) -> Option<Vec<String>> {
+    let path = pick_input(palette, "Index · which video or folder?").ok()??;
+    let mut argv = vec!["cerul".into(), "index".into(), path];
+    let dry = confirm(palette, &argv).ok()??;
+    let mut extra: Vec<String> = argv.split_off(2);
+    if dry {
+        extra.push("--dry-run".into());
+    }
+    Some(extra)
+}
+
+/// Search asks one question, because a query is the only thing it needs.
+fn search(palette: &Palette) -> Option<Vec<String>> {
+    let query = input(
+        palette,
+        "Search · what do you want to find?",
+        "Describe a moment, or press Enter to leave.",
+    )
+    .ok()??;
+    Some(vec![query])
+}
+
+/// Offered under the home screen, so running `cerul` still shows what it always
+/// showed and the menu is an addition rather than a replacement.
+pub fn home_menu(palette: &Palette) -> Option<Vec<OsString>> {
+    if !interactive() {
+        return None;
+    }
+    let choices = [
+        Choice::new("Index a video so it can be searched", "", Some("index")),
+        Choice::new("Search indexed videos", "", Some("search")),
+        Choice::new(
+            "Annotate actions in a video or LeRobot dataset",
+            "",
+            Some("annotate"),
+        ),
+        Choice::new("Leave", "", None),
+    ];
+    let command = select(palette, "What do you want to do?", &choices).ok()??;
+    Some(vec!["cerul".into(), OsString::from(command?)])
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod credentials;
 #[cfg(test)]
 mod documentation_tests;
+mod guide;
 mod render;
 use anyhow::{Context, Result};
 use cerul::{
@@ -117,6 +118,15 @@ enum Command {
         /// Verify configured model endpoints with small test requests (cached for seven days).
         #[arg(long)]
         providers: bool,
+        /// Read the published annotations in time order instead of the summary.
+        #[arg(long)]
+        timeline: bool,
+        /// Only one semantic item, for example event.
+        #[arg(long, value_name = "ITEM", requires = "timeline")]
+        r#type: Option<String>,
+        /// Most annotation records to show per video.
+        #[arg(long, default_value_t = 50, value_name = "N", requires = "timeline")]
+        limit: usize,
     },
     /// Open a result from the last search in a video player, at its moment.
     Open {
@@ -135,6 +145,8 @@ enum Command {
     Annotate(AnnotateArgs),
     /// Remove indexed videos, or free the disk they and their caches use.
     Remove(RemoveArgs),
+    /// Print or install the agent skill that teaches this CLI to a coding agent.
+    Skill(SkillArgs),
     /// Print a shell completion script, for example: cerul completions zsh.
     ///
     /// Hidden from the command list: it is run once when setting up a shell, and
@@ -144,6 +156,41 @@ enum Command {
         /// Shell to generate for.
         shell: clap_complete::Shell,
     },
+}
+#[derive(Args)]
+struct SkillArgs {
+    /// Install for this agent: claude, codex, or pi.
+    #[arg(long, value_name = "AGENT", conflicts_with = "print")]
+    install: Option<Agent>,
+    /// Install into this skills directory instead of an agent's own.
+    #[arg(long, value_name = "DIR", conflicts_with = "print")]
+    dir: Option<PathBuf>,
+    /// Write the skill to stdout instead of installing it.
+    #[arg(long)]
+    print: bool,
+}
+/// Agents that read the same skill format from a known directory.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+enum Agent {
+    Claude,
+    Codex,
+    Pi,
+}
+impl Agent {
+    fn directory(&self, home: &Path) -> PathBuf {
+        match self {
+            Self::Claude => home.join(".claude/skills"),
+            Self::Codex => home.join(".codex/skills"),
+            Self::Pi => home.join(".pi/agent/skills"),
+        }
+    }
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Pi => "pi",
+        }
+    }
 }
 #[derive(Args)]
 struct AuthArgs {
@@ -335,6 +382,198 @@ fn exit_code(error: &anyhow::Error) -> u8 {
     }
 }
 
+/// Marks a file this build wrote, so installing again replaces Cerul's own copy
+/// and never a file somebody edited by hand.
+const SKILL_MARKER: &str = "generated-by: cerul";
+
+/// The skill's command section, generated from this build's own argument
+/// definitions so that it cannot drift from `--help`.
+fn command_reference() -> String {
+    let mut command = Cli::command();
+    command.build();
+    let mut text = String::new();
+    let describe = |argument: &clap::Arg| -> String {
+        let takes_values = argument.get_action().takes_values();
+        let mut name = match (argument.get_long(), argument.get_short()) {
+            (Some(long), _) => format!("--{long}"),
+            (None, Some(short)) => format!("-{short}"),
+            (None, None) => format!(
+                "<{}>{}",
+                argument.get_id().as_str().to_uppercase().replace('_', "-"),
+                // Only a positional that really accepts several values is
+                // written as one; the rest take exactly one argument.
+                match argument.get_num_args() {
+                    Some(range) if range.max_values() > 1 => "...",
+                    _ => "",
+                }
+            ),
+        };
+        if takes_values
+            && argument.get_long().is_some()
+            && let Some(values) = argument.get_value_names()
+        {
+            name.push_str(&format!(" <{}>", values.join("> <")));
+        }
+        let mut help = argument
+            .get_help()
+            .map(|help| help.to_string().replace('\n', " "))
+            .unwrap_or_default();
+        // A default only means something where a value can be given; printing
+        // "default false" for every flag teaches nothing.
+        let defaults: Vec<String> = argument
+            .get_default_values()
+            .iter()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect();
+        if takes_values && !defaults.is_empty() {
+            help.push_str(&format!(" (default {})", defaults.join(", ")));
+        }
+        format!("  {name:<26}  {}\n", help.trim())
+    };
+    let listed = |argument: &&clap::Arg| {
+        !argument.is_hide_set() && !matches!(argument.get_id().as_str(), "help" | "version")
+    };
+    text.push_str("These options work on every command:\n\n");
+    for argument in command.get_arguments().filter(listed) {
+        text.push_str(&describe(argument));
+    }
+    for subcommand in command.get_subcommands().filter(|c| !c.is_hide_set()) {
+        text.push_str(&format!("\n### cerul {}\n\n", subcommand.get_name()));
+        if let Some(about) = subcommand.get_about() {
+            text.push_str(&format!("{}\n\n", about.to_string().replace('\n', " ")));
+        }
+        // Global options belong to the list above; repeating them under each
+        // command turns the reference into something nobody reads.
+        let mut arguments = subcommand
+            .get_arguments()
+            .filter(|argument| listed(argument) && !argument.is_global_set())
+            .peekable();
+        if arguments.peek().is_none() {
+            for nested in subcommand.get_subcommands().filter(|c| !c.is_hide_set()) {
+                text.push_str(&format!(
+                    "  cerul {} {:<20}  {}\n",
+                    subcommand.get_name(),
+                    nested.get_name(),
+                    nested
+                        .get_about()
+                        .map(|about| about.to_string().replace('\n', " "))
+                        .unwrap_or_default()
+                ));
+            }
+            continue;
+        }
+        for argument in arguments {
+            text.push_str(&describe(argument));
+        }
+    }
+    text
+}
+
+/// The skill file exactly as it is installed and as it is committed to the
+/// repository, so a person can take either copy and get the same instructions.
+fn skill_text() -> String {
+    let template = include_str!("../prompts/skill.md");
+    let (front, body) = template
+        .split_once("---\n")
+        .and_then(|(_, rest)| rest.split_once("\n---\n"))
+        .map(|(front, body)| (front.to_owned(), body.to_owned()))
+        .unwrap_or_else(|| (String::new(), template.to_owned()));
+    format!(
+        "---\n{front}\n{SKILL_MARKER} {}\n---\n{}\n{}",
+        env!("CARGO_PKG_VERSION"),
+        body.trim_end(),
+        command_reference()
+    )
+}
+
+#[derive(serde::Serialize)]
+struct SkillReport {
+    version: String,
+    /// Where the file was actually written.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    installed: Option<PathBuf>,
+    /// Where `--dry-run` would have written it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    planned: Option<PathBuf>,
+    targets: BTreeMap<String, PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skill: Option<String>,
+}
+
+/// A command that continues unfinished work. It repeats the original invocation
+/// and changes only what the failure calls for, so running it is always safe:
+/// finished windows are reused and nothing is recomputed on purpose.
+#[derive(Debug, Clone, serde::Serialize)]
+struct Retry {
+    argv: Vec<String>,
+    reason: &'static str,
+}
+
+/// Provider wording differs by endpoint, so the categories are matched on the
+/// signals every one of them sends rather than on one vendor's message.
+fn rate_limited(error: &str) -> bool {
+    let text = error.to_lowercase();
+    [
+        "429",
+        "rate limit",
+        "rate-limit",
+        "resource_exhausted",
+        "quota",
+    ]
+    .iter()
+    .any(|signal| text.contains(signal))
+}
+
+fn retry_after(report: &cerul::annotate::pipeline::Report, original: &[String]) -> Option<Retry> {
+    if !report.partial || report.dry_run {
+        return None;
+    }
+    let limited = report
+        .modules
+        .iter()
+        .filter_map(|module| module.error.as_deref())
+        .any(rate_limited);
+    let (program, rest) = original.split_first()?;
+    let mut argv = vec![
+        Path::new(program)
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| program.clone()),
+    ];
+    // The rate cap is the one argument this command is allowed to replace.
+    let mut rpm: Option<u32> = None;
+    let mut expecting = false;
+    for argument in rest {
+        if expecting {
+            expecting = false;
+            rpm = argument.parse().ok();
+            continue;
+        }
+        if argument == "--rpm" {
+            expecting = true;
+            continue;
+        }
+        if let Some(value) = argument.strip_prefix("--rpm=") {
+            rpm = value.parse().ok();
+            continue;
+        }
+        argv.push(argument.clone());
+    }
+    let reason = if limited { "rate_limit" } else { "incomplete" };
+    // Halving a cap the person already chose respects their intent; a first
+    // limit starts low enough that a retry is worth attempting at all.
+    let next = match (limited, rpm) {
+        (true, Some(current)) => Some((current / 2).max(1)),
+        (true, None) => Some(6),
+        (false, current) => current,
+    };
+    if let Some(value) = next {
+        argv.push("--rpm".into());
+        argv.push(value.to_string());
+    }
+    Some(Retry { argv, reason })
+}
+
 /// Everything a command can produce. JSON mode serializes it; human mode renders it.
 enum Outcome {
     Home(cerul::status::Status, render::ModelSummary),
@@ -342,7 +581,11 @@ enum Outcome {
         status: cerul::status::Status,
         models: render::ModelSummary,
         probed: bool,
+        /// A person who named a path wants the files, not only the summary.
+        detail: bool,
     },
+    Timeline(cerul::status::Timeline, Option<String>),
+    Skill(SkillReport),
     Auth(render::KeyState, Option<&'static str>),
     Remove(
         cerul::clean::Report,
@@ -358,7 +601,11 @@ enum Outcome {
     },
     Index(pipeline::Report, BTreeMap<String, PathBuf>),
     Search(cerul::search::Report, render::SearchContext),
-    Annotate(cerul::annotate::pipeline::Report, BTreeMap<String, PathBuf>),
+    Annotate(
+        cerul::annotate::pipeline::Report,
+        BTreeMap<String, PathBuf>,
+        Option<Retry>,
+    ),
 }
 impl Outcome {
     fn json(&self) -> Result<Value> {
@@ -385,7 +632,17 @@ impl Outcome {
             Outcome::Index(report, _) => serde_json::to_value(report)?,
             Outcome::Search(report, _) => serde_json::to_value(report)?,
             Outcome::Remove(report, _, _) => serde_json::to_value(report)?,
-            Outcome::Annotate(report, _) => serde_json::to_value(report)?,
+            Outcome::Timeline(timeline, _) => serde_json::to_value(timeline)?,
+            Outcome::Skill(report) => serde_json::to_value(report)?,
+            Outcome::Annotate(report, _, retry) => {
+                let mut value = serde_json::to_value(report)?;
+                // Unfinished work needs a command, not a description of one: this
+                // is the original invocation with only the failure's fix applied.
+                if let Some(retry) = retry {
+                    value["retry"] = serde_json::to_value(retry)?;
+                }
+                value
+            }
         })
     }
     fn render(&self, out: &mut dyn Write, palette: &Palette) -> io::Result<()> {
@@ -395,7 +652,23 @@ impl Outcome {
                 status,
                 models,
                 probed,
-            } => render::status(out, palette, status, models, *probed),
+                detail,
+            } => render::status(out, palette, status, models, *probed, *detail),
+            Outcome::Timeline(timeline, kind) => {
+                render::timeline(out, palette, timeline, kind.as_deref())
+            }
+            Outcome::Skill(report) => match &report.skill {
+                // The printed skill is the file itself: no colour, no heading,
+                // nothing a redirect would have to strip back out.
+                Some(text) => write!(out, "{text}"),
+                None => render::skill(
+                    out,
+                    palette,
+                    report.installed.as_deref(),
+                    report.planned.as_deref(),
+                    &report.targets,
+                ),
+            },
             Outcome::Auth(key, action) => {
                 match action {
                     Some("set") => {
@@ -432,7 +705,12 @@ impl Outcome {
             Outcome::Remove(report, names, unknown) => {
                 render::remove(out, palette, report, names, unknown)
             }
-            Outcome::Annotate(report, names) => render::annotate(out, palette, report, names),
+            Outcome::Annotate(report, names, retry) => {
+                let command = retry
+                    .as_ref()
+                    .map(|retry| render::shell_command(&retry.argv));
+                render::annotate(out, palette, report, names, command.as_deref())
+            }
         }
     }
 }
@@ -668,7 +946,45 @@ async fn execute(cli: &Cli, sink: &Sink, cancel: CancellationToken) -> Result<(O
             let config = config(cli).map_err(|e| category(2, e))?;
             Ok((Outcome::Home(status, models(&config)), 0))
         }
-        Some(Command::Status { path, providers }) => {
+        Some(Command::Status {
+            path,
+            providers,
+            timeline,
+            r#type,
+            limit,
+        }) => {
+            if *timeline {
+                anyhow::ensure!(
+                    !providers,
+                    CliError(
+                        2,
+                        "--timeline reads local files; --providers checks endpoints".into()
+                    )
+                );
+                anyhow::ensure!(*limit > 0, CliError(2, "--limit must be at least 1".into()));
+                if let Some(kind) = r#type {
+                    let item = kind.strip_prefix("semantic.").unwrap_or(kind);
+                    anyhow::ensure!(
+                        cerul::annotations::SEMANTIC_ITEMS.contains(&item),
+                        CliError(
+                            2,
+                            format!(
+                                "unknown annotation type {item}; choose one of: {}",
+                                cerul::annotations::SEMANTIC_ITEMS.join(", ")
+                            )
+                        )
+                    );
+                }
+                let timeline = cerul::status::timeline(
+                    &workspace,
+                    path.as_deref(),
+                    &cerul::status::TimelineOptions {
+                        kind: r#type.clone(),
+                        limit: *limit,
+                    },
+                )?;
+                return Ok((Outcome::Timeline(timeline, r#type.clone()), 0));
+            }
             let mut status = cerul::status::inspect(&workspace, path.as_deref())?;
             let config = config(cli).map_err(|e| category(2, e))?;
             let mut partial = false;
@@ -690,6 +1006,7 @@ async fn execute(cli: &Cli, sink: &Sink, cancel: CancellationToken) -> Result<(O
                     status,
                     models: models(&config),
                     probed: *providers && !cli.dry_run,
+                    detail: path.is_some(),
                 },
                 if partial { 6 } else { 0 },
             ))
@@ -828,7 +1145,11 @@ async fn execute(cli: &Cli, sink: &Sink, cancel: CancellationToken) -> Result<(O
             .await?;
             sink.finish();
             let code = if report.partial { 6 } else { 0 };
-            Ok((Outcome::Annotate(report, names(&workspace)), code))
+            let invocation: Vec<String> = std::env::args_os()
+                .map(|argument| argument.to_string_lossy().into_owned())
+                .collect();
+            let retry = retry_after(&report, &invocation);
+            Ok((Outcome::Annotate(report, names(&workspace), retry), code))
         }
         Some(Command::Search(args)) => {
             let config = config(cli).map_err(|e| category(2, e))?;
@@ -899,6 +1220,79 @@ async fn execute(cli: &Cli, sink: &Sink, cancel: CancellationToken) -> Result<(O
                         player: render::Player::detect(),
                     },
                 ),
+                0,
+            ))
+        }
+        Some(Command::Skill(args)) => {
+            let home = std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .context("set HOME to locate an agent's skills directory")
+                .map_err(|e| category(2, e))?;
+            let targets: BTreeMap<String, PathBuf> = [Agent::Claude, Agent::Codex, Agent::Pi]
+                .iter()
+                .map(|agent| {
+                    (
+                        agent.label().to_owned(),
+                        agent.directory(&home).join("cerul/SKILL.md"),
+                    )
+                })
+                .collect();
+            let version = env!("CARGO_PKG_VERSION").to_owned();
+            if args.print {
+                return Ok((
+                    Outcome::Skill(SkillReport {
+                        version,
+                        installed: None,
+                        planned: None,
+                        targets,
+                        skill: Some(skill_text()),
+                    }),
+                    0,
+                ));
+            }
+            let destination = match (&args.dir, &args.install) {
+                (Some(directory), _) => Some(directory.join("cerul/SKILL.md")),
+                (None, Some(agent)) => Some(agent.directory(&home).join("cerul/SKILL.md")),
+                (None, None) => None,
+            };
+            let (mut installed, mut planned) = (None, None);
+            if let Some(path) = destination {
+                // Replacing Cerul's own copy is routine; replacing a file someone
+                // wrote by hand is not, so the marker has to be there first.
+                if path.exists() {
+                    let existing = fs::read_to_string(&path).unwrap_or_default();
+                    anyhow::ensure!(
+                        existing.contains(SKILL_MARKER),
+                        CliError(
+                            2,
+                            format!(
+                                "{} was not written by cerul; move it aside first",
+                                path.display()
+                            )
+                        )
+                    );
+                }
+                if cli.dry_run {
+                    planned = Some(path);
+                } else {
+                    let parent = path.parent().context("skill path has no directory")?;
+                    fs::create_dir_all(parent)
+                        .with_context(|| format!("could not create {}", parent.display()))
+                        .map_err(|e| category(4, e))?;
+                    fs::write(&path, skill_text())
+                        .with_context(|| format!("could not write {}", path.display()))
+                        .map_err(|e| category(4, e))?;
+                    installed = Some(path);
+                }
+            }
+            Ok((
+                Outcome::Skill(SkillReport {
+                    version,
+                    installed,
+                    planned,
+                    targets,
+                    skill: None,
+                }),
                 0,
             ))
         }
@@ -1144,9 +1538,25 @@ fn hint(code: u8, error: &anyhow::Error, env: &str) -> Option<String> {
 
 #[tokio::main]
 async fn main() -> std::process::ExitCode {
-    let arguments: Vec<_> = std::env::args_os().collect();
+    run(std::env::args_os().collect(), true).await
+}
+
+/// One invocation, from arguments to exit code. `guided` is false for the run a
+/// menu started, so a completed command can never open another menu.
+async fn run(arguments: Vec<std::ffi::OsString>, guided: bool) -> std::process::ExitCode {
+    let prompts = Palette::new(console::colors_enabled_stderr());
+    // Guidance completes the arguments and then steps out of the way: what runs
+    // is what the ordinary parser makes of them, exactly as if they were typed.
+    let arguments = match guided {
+        true => match guide::complete(arguments.clone(), &prompts) {
+            guide::Guided::Completed(completed) => completed,
+            guide::Guided::Untouched => arguments,
+            guide::Guided::Left => return std::process::ExitCode::SUCCESS,
+        },
+        false => arguments,
+    };
     let json = arguments.iter().any(|arg| arg == "--json");
-    let cli = match Cli::try_parse_from(arguments) {
+    let cli = match Cli::try_parse_from(arguments.iter().cloned()) {
         Ok(cli) => cli,
         Err(error) => {
             if matches!(
@@ -1264,6 +1674,18 @@ async fn main() -> std::process::ExitCode {
         }
         _ => Ok(()),
     };
+    // The home screen keeps its own output and the menu is offered underneath
+    // it, so running `cerul` still shows everything it always showed.
+    if guided
+        && code == 0
+        && written.is_ok()
+        && cli.command.is_none()
+        && mode == Mode::Human
+        && !cli.quiet
+        && let Some(next) = guide::home_menu(&prompts)
+    {
+        return Box::pin(run(next, false)).await;
+    }
     match written {
         Ok(()) => std::process::ExitCode::from(code),
         Err(error) if error.kind() == io::ErrorKind::BrokenPipe => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,7 @@ struct SkillArgs {
     #[arg(long, value_name = "AGENT", conflicts_with = "print")]
     install: Option<Agent>,
     /// Install into this skills directory instead of an agent's own.
-    #[arg(long, value_name = "DIR", conflicts_with = "print")]
+    #[arg(long, value_name = "DIR", conflicts_with_all = ["print", "install"])]
     dir: Option<PathBuf>,
     /// Write the skill to stdout instead of installing it.
     #[arg(long)]
@@ -388,6 +388,10 @@ fn exit_code(error: &anyhow::Error) -> u8 {
 /// Marks a file this build wrote, so installing again replaces Cerul's own copy
 /// and never a file somebody edited by hand.
 const SKILL_MARKER: &str = "generated-by: cerul";
+/// Records what the file said when Cerul wrote it. A version alone cannot answer
+/// "was this edited?" for a file an older build installed, and that is exactly
+/// the file an upgrade is about to replace.
+const SKILL_DIGEST: &str = "generated-sha256:";
 
 /// The skill's command section, generated from this build's own argument
 /// definitions so that it cannot drift from `--help`.
@@ -481,12 +485,27 @@ fn skill_text() -> String {
         .and_then(|(_, rest)| rest.split_once("\n---\n"))
         .map(|(front, body)| (front.to_owned(), body.to_owned()))
         .unwrap_or_else(|| (String::new(), template.to_owned()));
+    let body = format!("{}\n{}", body.trim_end(), command_reference());
     format!(
-        "---\n{front}\n{SKILL_MARKER} {}\n---\n{}\n{}",
+        "---\n{front}\n{SKILL_MARKER} {}\n{SKILL_DIGEST} {}\n---\n{body}",
         env!("CARGO_PKG_VERSION"),
-        body.trim_end(),
-        command_reference()
+        cerul::storage::sha256_hex(&body)
     )
+}
+
+/// Whether an installed skill still says what Cerul wrote in it, whichever build
+/// wrote it. A file without the recorded digest was not written by this command.
+fn skill_unchanged(existing: &str) -> bool {
+    let Some((front, body)) = existing
+        .strip_prefix("---\n")
+        .and_then(|rest| rest.split_once("\n---\n"))
+    else {
+        return false;
+    };
+    front
+        .lines()
+        .find_map(|line| line.trim().strip_prefix(SKILL_DIGEST))
+        .is_some_and(|digest| digest.trim() == cerul::storage::sha256_hex(body))
 }
 
 #[derive(serde::Serialize)]
@@ -551,20 +570,17 @@ fn skill(cli: &Cli, args: &SkillArgs) -> Result<(Outcome, u8)> {
     if let Some(path) = destination {
         if path.is_file() {
             let existing = fs::read_to_string(&path).unwrap_or_default();
-            // Replacing an older copy is an upgrade and needs no
-            // ceremony. Replacing this version's copy when it no longer
-            // matches means somebody edited it, and their work is not
-            // this command's to discard.
-            let ours = existing.contains(&format!("{SKILL_MARKER} {version}"));
-            let edited = ours && existing != text;
+            // Replacing an untouched copy is an upgrade and needs no ceremony,
+            // whichever build wrote it. Anything else is somebody's work, and it
+            // is not this command's to discard.
             anyhow::ensure!(
-                args.force || (existing.contains(SKILL_MARKER) && !edited),
+                args.force || skill_unchanged(&existing),
                 CliError(
                     2,
                     format!(
                         "{} was {}; move it aside, or pass --force to replace it",
                         path.display(),
-                        match edited {
+                        match existing.contains(SKILL_MARKER) {
                             true => "changed after cerul wrote it",
                             false => "not written by cerul",
                         }
@@ -624,13 +640,10 @@ fn retry_after(
         .iter()
         .filter_map(|module| module.error.as_deref())
         .any(rate_limited);
+    // Keeping the program exactly as it was invoked: a path was probably used
+    // because the binary is not on PATH, and shortening it would break the copy.
     let (program, rest) = original.split_first()?;
-    let mut argv = vec![
-        Path::new(program)
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned())
-            .unwrap_or_else(|| program.clone()),
-    ];
+    let mut argv = vec![program.clone()];
     // The rate cap is the one argument this command is allowed to replace.
     let mut rpm: Option<u32> = None;
     let mut expecting = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,6 +168,9 @@ struct SkillArgs {
     /// Write the skill to stdout instead of installing it.
     #[arg(long)]
     print: bool,
+    /// Replace an installed skill even when it was changed after it was written.
+    #[arg(long)]
+    force: bool,
 }
 /// Agents that read the same skill format from a known directory.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
@@ -500,13 +503,98 @@ struct SkillReport {
     skill: Option<String>,
 }
 
-/// A command that continues unfinished work. It repeats the original invocation
-/// and changes only what the failure calls for, so running it is always safe:
-/// finished windows are reused and nothing is recomputed on purpose.
-#[derive(Debug, Clone, serde::Serialize)]
-struct Retry {
-    argv: Vec<String>,
-    reason: &'static str,
+/// Writing the skill needs no workspace and, unless an agent's own directory is
+/// named, no home directory either: a container with neither can still redirect
+/// the file somewhere it can use.
+fn skill(cli: &Cli, args: &SkillArgs) -> Result<(Outcome, u8)> {
+    // Printing the skill, or writing it to a named directory, needs no
+    // home directory. Only naming an agent's own directory does, so a
+    // container without HOME can still redirect the file somewhere.
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let targets: BTreeMap<String, PathBuf> = home
+        .iter()
+        .flat_map(|home| {
+            [Agent::Claude, Agent::Codex, Agent::Pi].map(|agent| {
+                (
+                    agent.label().to_owned(),
+                    agent.directory(home).join("cerul/SKILL.md"),
+                )
+            })
+        })
+        .collect();
+    let version = env!("CARGO_PKG_VERSION").to_owned();
+    let text = skill_text();
+    if args.print {
+        return Ok((
+            Outcome::Skill(SkillReport {
+                version,
+                installed: None,
+                planned: None,
+                targets,
+                skill: Some(text),
+            }),
+            0,
+        ));
+    }
+    let destination = match (&args.dir, &args.install) {
+        (Some(directory), _) => Some(directory.join("cerul/SKILL.md")),
+        (None, Some(agent)) => {
+            let home = home
+                .as_ref()
+                .context("set HOME, or choose a directory with --dir")
+                .map_err(|e| category(2, e))?;
+            Some(agent.directory(home).join("cerul/SKILL.md"))
+        }
+        (None, None) => None,
+    };
+    let (mut installed, mut planned) = (None, None);
+    if let Some(path) = destination {
+        if path.is_file() {
+            let existing = fs::read_to_string(&path).unwrap_or_default();
+            // Replacing an older copy is an upgrade and needs no
+            // ceremony. Replacing this version's copy when it no longer
+            // matches means somebody edited it, and their work is not
+            // this command's to discard.
+            let ours = existing.contains(&format!("{SKILL_MARKER} {version}"));
+            let edited = ours && existing != text;
+            anyhow::ensure!(
+                args.force || (existing.contains(SKILL_MARKER) && !edited),
+                CliError(
+                    2,
+                    format!(
+                        "{} was {}; move it aside, or pass --force to replace it",
+                        path.display(),
+                        match edited {
+                            true => "changed after cerul wrote it",
+                            false => "not written by cerul",
+                        }
+                    )
+                )
+            );
+        }
+        if cli.dry_run {
+            planned = Some(path);
+        } else {
+            let parent = path.parent().context("skill path has no directory")?;
+            fs::create_dir_all(parent)
+                .with_context(|| format!("could not create {}", parent.display()))
+                .map_err(|e| category(4, e))?;
+            fs::write(&path, &text)
+                .with_context(|| format!("could not write {}", path.display()))
+                .map_err(|e| category(4, e))?;
+            installed = Some(path);
+        }
+    }
+    Ok((
+        Outcome::Skill(SkillReport {
+            version,
+            installed,
+            planned,
+            targets,
+            skill: None,
+        }),
+        0,
+    ))
 }
 
 /// Provider wording differs by endpoint, so the categories are matched on the
@@ -524,7 +612,10 @@ fn rate_limited(error: &str) -> bool {
     .any(|signal| text.contains(signal))
 }
 
-fn retry_after(report: &cerul::annotate::pipeline::Report, original: &[String]) -> Option<Retry> {
+fn retry_after(
+    report: &cerul::annotate::pipeline::Report,
+    original: &[String],
+) -> Option<cerul::annotate::pipeline::Retry> {
     if !report.partial || report.dry_run {
         return None;
     }
@@ -559,7 +650,10 @@ fn retry_after(report: &cerul::annotate::pipeline::Report, original: &[String]) 
         }
         argv.push(argument.clone());
     }
-    let reason = if limited { "rate_limit" } else { "incomplete" };
+    let reason = match limited {
+        true => cerul::annotate::pipeline::RetryReason::RateLimit,
+        false => cerul::annotate::pipeline::RetryReason::Incomplete,
+    };
     // Halving a cap the person already chose respects their intent; a first
     // limit starts low enough that a retry is worth attempting at all.
     let next = match (limited, rpm) {
@@ -571,7 +665,7 @@ fn retry_after(report: &cerul::annotate::pipeline::Report, original: &[String]) 
         argv.push("--rpm".into());
         argv.push(value.to_string());
     }
-    Some(Retry { argv, reason })
+    Some(cerul::annotate::pipeline::Retry { argv, reason })
 }
 
 /// Everything a command can produce. JSON mode serializes it; human mode renders it.
@@ -601,11 +695,7 @@ enum Outcome {
     },
     Index(pipeline::Report, BTreeMap<String, PathBuf>),
     Search(cerul::search::Report, render::SearchContext),
-    Annotate(
-        cerul::annotate::pipeline::Report,
-        BTreeMap<String, PathBuf>,
-        Option<Retry>,
-    ),
+    Annotate(cerul::annotate::pipeline::Report, BTreeMap<String, PathBuf>),
 }
 impl Outcome {
     fn json(&self) -> Result<Value> {
@@ -634,15 +724,7 @@ impl Outcome {
             Outcome::Remove(report, _, _) => serde_json::to_value(report)?,
             Outcome::Timeline(timeline, _) => serde_json::to_value(timeline)?,
             Outcome::Skill(report) => serde_json::to_value(report)?,
-            Outcome::Annotate(report, _, retry) => {
-                let mut value = serde_json::to_value(report)?;
-                // Unfinished work needs a command, not a description of one: this
-                // is the original invocation with only the failure's fix applied.
-                if let Some(retry) = retry {
-                    value["retry"] = serde_json::to_value(retry)?;
-                }
-                value
-            }
+            Outcome::Annotate(report, _) => serde_json::to_value(report)?,
         })
     }
     fn render(&self, out: &mut dyn Write, palette: &Palette) -> io::Result<()> {
@@ -705,8 +787,9 @@ impl Outcome {
             Outcome::Remove(report, names, unknown) => {
                 render::remove(out, palette, report, names, unknown)
             }
-            Outcome::Annotate(report, names, retry) => {
-                let command = retry
+            Outcome::Annotate(report, names) => {
+                let command = report
+                    .retry
                     .as_ref()
                     .map(|retry| render::shell_command(&retry.argv));
                 render::annotate(out, palette, report, names, command.as_deref())
@@ -928,7 +1011,17 @@ fn names(workspace: &Path) -> BTreeMap<String, PathBuf> {
 }
 const MEDIA_NOTICE: &str = "Using Gemini (media may be sent, usage billed to your key):";
 
-async fn execute(cli: &Cli, sink: &Sink, cancel: CancellationToken) -> Result<(Outcome, u8)> {
+async fn execute(
+    cli: &Cli,
+    invocation: &[String],
+    sink: &Sink,
+    cancel: CancellationToken,
+) -> Result<(Outcome, u8)> {
+    // Writing the skill touches no workspace, so it is answered before one has
+    // to exist.
+    if let Some(Command::Skill(args)) = &cli.command {
+        return skill(cli, args);
+    }
     let workspace = cli
         .workspace
         .clone()
@@ -1134,7 +1227,7 @@ async fn execute(cli: &Cli, sink: &Sink, cancel: CancellationToken) -> Result<(O
             readable(&args.paths)?;
             cerul::media::check_dependencies().map_err(|e| category(3, e))?;
             let events = sink.clone();
-            let report = cerul::annotate::pipeline::run(
+            let mut report = cerul::annotate::pipeline::run(
                 &args.paths,
                 &workspace,
                 &config,
@@ -1145,11 +1238,10 @@ async fn execute(cli: &Cli, sink: &Sink, cancel: CancellationToken) -> Result<(O
             .await?;
             sink.finish();
             let code = if report.partial { 6 } else { 0 };
-            let invocation: Vec<String> = std::env::args_os()
-                .map(|argument| argument.to_string_lossy().into_owned())
-                .collect();
-            let retry = retry_after(&report, &invocation);
-            Ok((Outcome::Annotate(report, names(&workspace), retry), code))
+            // Guidance completes an argument list before it is parsed, so the
+            // command that continues this work is built from what actually ran.
+            report.retry = retry_after(&report, invocation);
+            Ok((Outcome::Annotate(report, names(&workspace)), code))
         }
         Some(Command::Search(args)) => {
             let config = config(cli).map_err(|e| category(2, e))?;
@@ -1223,78 +1315,8 @@ async fn execute(cli: &Cli, sink: &Sink, cancel: CancellationToken) -> Result<(O
                 0,
             ))
         }
-        Some(Command::Skill(args)) => {
-            let home = std::env::var_os("HOME")
-                .map(PathBuf::from)
-                .context("set HOME to locate an agent's skills directory")
-                .map_err(|e| category(2, e))?;
-            let targets: BTreeMap<String, PathBuf> = [Agent::Claude, Agent::Codex, Agent::Pi]
-                .iter()
-                .map(|agent| {
-                    (
-                        agent.label().to_owned(),
-                        agent.directory(&home).join("cerul/SKILL.md"),
-                    )
-                })
-                .collect();
-            let version = env!("CARGO_PKG_VERSION").to_owned();
-            if args.print {
-                return Ok((
-                    Outcome::Skill(SkillReport {
-                        version,
-                        installed: None,
-                        planned: None,
-                        targets,
-                        skill: Some(skill_text()),
-                    }),
-                    0,
-                ));
-            }
-            let destination = match (&args.dir, &args.install) {
-                (Some(directory), _) => Some(directory.join("cerul/SKILL.md")),
-                (None, Some(agent)) => Some(agent.directory(&home).join("cerul/SKILL.md")),
-                (None, None) => None,
-            };
-            let (mut installed, mut planned) = (None, None);
-            if let Some(path) = destination {
-                // Replacing Cerul's own copy is routine; replacing a file someone
-                // wrote by hand is not, so the marker has to be there first.
-                if path.exists() {
-                    let existing = fs::read_to_string(&path).unwrap_or_default();
-                    anyhow::ensure!(
-                        existing.contains(SKILL_MARKER),
-                        CliError(
-                            2,
-                            format!(
-                                "{} was not written by cerul; move it aside first",
-                                path.display()
-                            )
-                        )
-                    );
-                }
-                if cli.dry_run {
-                    planned = Some(path);
-                } else {
-                    let parent = path.parent().context("skill path has no directory")?;
-                    fs::create_dir_all(parent)
-                        .with_context(|| format!("could not create {}", parent.display()))
-                        .map_err(|e| category(4, e))?;
-                    fs::write(&path, skill_text())
-                        .with_context(|| format!("could not write {}", path.display()))
-                        .map_err(|e| category(4, e))?;
-                    installed = Some(path);
-                }
-            }
-            Ok((
-                Outcome::Skill(SkillReport {
-                    version,
-                    installed,
-                    planned,
-                    targets,
-                    skill: None,
-                }),
-                0,
-            ))
+        Some(Command::Skill(_)) => {
+            unreachable!("the skill is written before a workspace is resolved")
         }
         Some(Command::Completions { .. }) => {
             unreachable!("completions are printed before the runtime starts")
@@ -1538,24 +1560,27 @@ fn hint(code: u8, error: &anyhow::Error, env: &str) -> Option<String> {
 
 #[tokio::main]
 async fn main() -> std::process::ExitCode {
-    run(std::env::args_os().collect(), true).await
+    run(std::env::args_os().collect(), guide::Entry::Typed).await
 }
 
 /// One invocation, from arguments to exit code. `guided` is false for the run a
 /// menu started, so a completed command can never open another menu.
-async fn run(arguments: Vec<std::ffi::OsString>, guided: bool) -> std::process::ExitCode {
+async fn run(arguments: Vec<std::ffi::OsString>, entry: guide::Entry) -> std::process::ExitCode {
     let prompts = Palette::new(console::colors_enabled_stderr());
     // Guidance completes the arguments and then steps out of the way: what runs
     // is what the ordinary parser makes of them, exactly as if they were typed.
-    let arguments = match guided {
-        true => match guide::complete(arguments.clone(), &prompts) {
-            guide::Guided::Completed(completed) => completed,
-            guide::Guided::Untouched => arguments,
-            guide::Guided::Left => return std::process::ExitCode::SUCCESS,
-        },
-        false => arguments,
+    let typed = arguments.clone();
+    let arguments = match guide::complete(arguments.clone(), &prompts, entry) {
+        guide::Guided::Completed(completed) => completed,
+        guide::Guided::Untouched => arguments,
+        guide::Guided::Left => return std::process::ExitCode::SUCCESS,
     };
     let json = arguments.iter().any(|arg| arg == "--json");
+    // The command that ran, which is what a retry has to repeat.
+    let invocation: Vec<String> = arguments
+        .iter()
+        .map(|argument| argument.to_string_lossy().into_owned())
+        .collect();
     let cli = match Cli::try_parse_from(arguments.iter().cloned()) {
         Ok(cli) => cli,
         Err(error) => {
@@ -1615,8 +1640,11 @@ async fn run(arguments: Vec<std::ffi::OsString>, guided: bool) -> std::process::
     });
     let result = cerul::media::with_cancellation(cancel.clone(), async {
         let resolver = credentials::resolver(&cli, cancel.clone());
-        cerul::providers::with_credential_resolver(resolver, execute(&cli, &sink, cancel.clone()))
-            .await
+        cerul::providers::with_credential_resolver(
+            resolver,
+            execute(&cli, &invocation, &sink, cancel.clone()),
+        )
+        .await
     })
     .await;
     listener.abort();
@@ -1676,15 +1704,16 @@ async fn run(arguments: Vec<std::ffi::OsString>, guided: bool) -> std::process::
     };
     // The home screen keeps its own output and the menu is offered underneath
     // it, so running `cerul` still shows everything it always showed.
-    if guided
+    if entry == guide::Entry::Typed
         && code == 0
         && written.is_ok()
         && cli.command.is_none()
         && mode == Mode::Human
-        && !cli.quiet
-        && let Some(next) = guide::home_menu(&prompts)
+        && let Some(next) = guide::home_menu(&prompts, &typed)
     {
-        return Box::pin(run(next, false)).await;
+        // The command a menu chose still has to be completed, and a command can
+        // only reach the menu once, so this cannot ask twice.
+        return Box::pin(run(next, guide::Entry::Menu)).await;
     }
     match written {
         Ok(()) => std::process::ExitCode::from(code),

--- a/src/render.rs
+++ b/src/render.rs
@@ -13,7 +13,7 @@ use cerul::{
 use console::{Style, measure_text_width, truncate_str};
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     io::{self, IsTerminal, Write},
     path::{Path, PathBuf},
     time::Duration,
@@ -418,6 +418,53 @@ impl Progress {
                 };
                 self.println(&line);
             }
+            // A checkpoint moves no counter of its own: the progress event for the
+            // same window already drew it. It exists so a machine reader can tell
+            // durable work from work still only in memory.
+            Event::Checkpoint { .. } => {}
+            Event::Published {
+                episode,
+                annotation,
+                records,
+                ..
+            } => {
+                if self.quiet {
+                    return;
+                }
+                let label = station_label(&annotation);
+                let unit = format!("{records} record{}", if records == 1 { "" } else { "s" });
+                {
+                    let summary = format!("{} {unit}", label.to_lowercase());
+                    let summaries = self.finished.entry(episode.clone()).or_default();
+                    match summaries.iter_mut().find(|(name, _)| name == &annotation) {
+                        Some(slot) => slot.1 = summary,
+                        None => summaries.push((annotation.clone(), summary)),
+                    }
+                }
+                let message = format!(
+                    "{} {:<13} {}",
+                    self.palette.ok("✓"),
+                    label,
+                    self.palette.dim(&format!("{unit} · published"))
+                );
+                match self.bars.get(&(episode.clone(), annotation.clone())) {
+                    Some(bar) => {
+                        bar.set_style(
+                            ProgressStyle::with_template("    {prefix:<20!} {msg}")
+                                .expect("static template"),
+                        );
+                        bar.set_message(message);
+                        bar.finish();
+                    }
+                    None => {
+                        let name = self.name(&episode);
+                        self.println(&format!(
+                            "  {} {name}  {label}  {unit} · published",
+                            self.palette.ok("✓")
+                        ));
+                    }
+                }
+            }
             Event::Progress {
                 episode,
                 station,
@@ -516,9 +563,77 @@ fn next_steps(out: &mut dyn Write, palette: &Palette, items: &[(&str, &str)]) ->
         .unwrap_or(0);
     for (cmd, note) in items {
         let pad = " ".repeat(width - measure_text_width(cmd) + 4);
-        writeln!(out, "  {}{pad}{}", palette.cmd(cmd), palette.dim(note))?;
+        writeln!(
+            out,
+            "  {}{pad}{}",
+            palette.cmd(cmd),
+            palette.dim(note).trim_end()
+        )?;
     }
     Ok(())
+}
+
+/// The closing block of a result: what to run now that this finished. Three
+/// commands is the most anyone reads, so callers pass their best three.
+fn next_block(out: &mut dyn Write, palette: &Palette, items: &[(&str, &str)]) -> io::Result<()> {
+    if items.is_empty() {
+        return Ok(());
+    }
+    writeln!(out)?;
+    writeln!(out, "{}", palette.bold("Next"))?;
+    next_steps(out, palette, items)
+}
+
+/// Aligned `label  value` rows: the facts a screen states before its result.
+fn facts(out: &mut dyn Write, palette: &Palette, rows: &[(&str, String)]) -> io::Result<()> {
+    let width = rows
+        .iter()
+        .map(|(label, _)| measure_text_width(label))
+        .max()
+        .unwrap_or(0);
+    for (label, value) in rows {
+        if value.is_empty() {
+            continue;
+        }
+        let pad = " ".repeat(width - measure_text_width(label) + 3);
+        writeln!(out, "  {}{pad}{value}", palette.dim(label))?;
+    }
+    Ok(())
+}
+
+/// The `--semantic` value a person types, from the annotation's internal name.
+fn item_name(annotation: &str) -> &str {
+    let item = annotation.rsplit('/').next().unwrap_or(annotation);
+    item.strip_prefix("semantic.").unwrap_or(item)
+}
+
+/// Quotes one argument so a copied command survives spaces, quotes, and globs.
+pub fn shell_quote(value: &str) -> String {
+    let safe = |c: char| c.is_ascii_alphanumeric() || "-_./=:,@+".contains(c);
+    if !value.is_empty() && value.chars().all(safe) {
+        return value.to_owned();
+    }
+    format!("'{}'", value.replace('\'', r"'\''"))
+}
+
+/// One shell line that runs `argv` exactly, whatever the paths contain.
+pub fn shell_command(argv: &[String]) -> String {
+    argv.iter()
+        .map(|argument| shell_quote(argument))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// A path as a person would type it: `~` while that stays unambiguous, and the
+/// full quoted path once the characters would otherwise change what runs.
+pub fn shell_path(path: &Path) -> String {
+    let display = tilde(path);
+    let safe = |c: char| c.is_ascii_alphanumeric() || "-_./=:,@+~".contains(c);
+    if display.chars().all(safe) {
+        display
+    } else {
+        shell_quote(&path.to_string_lossy())
+    }
 }
 
 /// The screen shown for a bare `cerul`. Until the first video is searchable it
@@ -681,7 +796,24 @@ pub fn tilde(path: &Path) -> String {
     path.display().to_string()
 }
 
-fn checks(episode: &cerul::status::EpisodeStatus, palette: &Palette) -> String {
+/// The workspace overview. One row per video with a column per capability, so
+/// "indexed" stops standing for three different facts. `detail` adds the files
+/// a person needs when they asked about one path.
+pub fn status(
+    out: &mut dyn Write,
+    palette: &Palette,
+    status: &Status,
+    models: &ModelSummary,
+    probed: bool,
+    detail: bool,
+) -> io::Result<()> {
+    writeln!(
+        out,
+        "Workspace {}   {}",
+        tilde(&status.workspace),
+        palette.dim(&format!("·   cerul {}", status.version))
+    )?;
+    writeln!(out)?;
     let mark = |ready: bool| {
         if ready {
             palette.ok("✓")
@@ -689,90 +821,154 @@ fn checks(episode: &cerul::status::EpisodeStatus, palette: &Palette) -> String {
             palette.dim("–")
         }
     };
-    let has = |name: &str| episode.annotations.iter().any(|a| a == name);
-    let search = episode.embeddings.iter().any(|e| e.complete);
-    let semantic = episode
-        .annotations
-        .iter()
-        .any(|a| a.starts_with("semantic"));
-    let mut parts = vec![
-        format!("screen text {}", mark(has("screen_text"))),
-        format!("speech {}", mark(has("transcript"))),
-        format!("search {}", mark(search)),
-    ];
-    if semantic {
-        parts.push(format!("annotations {}", mark(true)));
-    }
-    if let Some(failed) = episode.embeddings.iter().find(|e| !e.complete) {
-        parts.push(palette.warn(&format!(
-            "search incomplete{}",
-            failed
-                .error
-                .as_deref()
-                .map(|e| format!(": {e}"))
-                .unwrap_or_default()
-        )));
-    }
-    if !episode.media_present {
-        parts.push(palette.warn("media missing"));
-    }
-    parts.join("   ")
-}
-
-pub fn status(
-    out: &mut dyn Write,
-    palette: &Palette,
-    status: &Status,
-    models: &ModelSummary,
-    probed: bool,
-) -> io::Result<()> {
-    writeln!(
-        out,
-        "Workspace  {}   ·   cerul {}",
-        tilde(&status.workspace),
-        status.version
-    )?;
-    writeln!(out)?;
-    writeln!(
-        out,
-        "{}",
-        palette.bold(&format!("Videos ({})", status.episodes.len()))
-    )?;
+    let search_state = |episode: &cerul::status::EpisodeStatus| -> (String, String) {
+        if episode.embeddings.iter().any(|state| state.complete) {
+            ("ready".into(), palette.ok("ready"))
+        } else if episode.embeddings.is_empty() {
+            ("–".into(), palette.dim("–"))
+        } else {
+            ("partial".into(), palette.warn("partial"))
+        }
+    };
+    let items = |episode: &cerul::status::EpisodeStatus| -> Vec<String> {
+        let mut names: Vec<String> = episode
+            .annotations
+            .iter()
+            .filter(|name| name.contains("semantic."))
+            .map(|name| item_name(name).to_owned())
+            .collect();
+        names.sort();
+        names.dedup();
+        names
+    };
+    let station = |episode: &cerul::status::EpisodeStatus, name: &str| {
+        episode
+            .annotations
+            .iter()
+            .any(|annotation| annotation == name || annotation.ends_with(&format!("/{name}")))
+    };
     if status.episodes.is_empty() {
         writeln!(
             out,
-            "  none yet   {}",
-            palette.dim("add one with: cerul index ./video.mp4")
+            "  {}",
+            palette.dim("no videos yet   ·   add one with: cerul index ./video.mp4")
         )?;
-    }
-    let width = status
-        .episodes
-        .iter()
-        .map(|e| measure_text_width(&file_name(&e.media)))
-        .max()
-        .unwrap_or(0)
-        .min(40);
-    for episode in &status.episodes {
-        let name = truncate_str(&file_name(&episode.media), 40, "…").to_string();
-        let pad = " ".repeat(width.saturating_sub(measure_text_width(&name)));
-        writeln!(out, "  {name}{pad}   {}", checks(episode, palette))?;
+    } else if console::Term::stdout().size().1 < 80 {
+        // Below 80 columns the row becomes a block: a wrapped table is unreadable
+        // and a truncated path is useless.
+        for episode in &status.episodes {
+            let (plain, styled) = search_state(episode);
+            let _ = plain;
+            writeln!(
+                out,
+                "  {}   {}",
+                palette.bold(&file_name(&episode.media)),
+                palette.dim(&episode.duration_us.map(clock).unwrap_or_default())
+            )?;
+            writeln!(
+                out,
+                "    search {styled}   screen text {}   speech {}",
+                mark(station(episode, "screen_text")),
+                mark(station(episode, "transcript"))
+            )?;
+            let labels = items(episode);
+            if !labels.is_empty() {
+                writeln!(
+                    out,
+                    "    {} {}",
+                    palette.dim("annotations"),
+                    labels.join(" ")
+                )?;
+            }
+            if detail {
+                writeln!(out, "    {}", palette.dim(&tilde(&episode.sidecar)))?;
+            }
+        }
+    } else {
+        let name_of = |episode: &cerul::status::EpisodeStatus| {
+            truncate_str(&file_name(&episode.media), 28, "…").to_string()
+        };
+        let width = status
+            .episodes
+            .iter()
+            .map(|episode| measure_text_width(&name_of(episode)))
+            .chain(std::iter::once(5))
+            .max()
+            .unwrap_or(5);
+        let pad = |text: &str, styled: &str, to: usize| {
+            format!(
+                "{styled}{}",
+                " ".repeat(to.saturating_sub(measure_text_width(text)))
+            )
+        };
         writeln!(
             out,
-            "    {}",
-            palette.dim(&format!("annotations: {}", tilde(&episode.sidecar)))
+            "  {}",
+            palette.dim(&format!(
+                "{:<width$}   {:<8} {:<9} {:<6} {:<8} {}",
+                "Video", "Length", "Search", "Text", "Speech", "Annotations"
+            ))
+        )?;
+        for episode in &status.episodes {
+            let name = name_of(episode);
+            let length = episode.duration_us.map(clock).unwrap_or_else(|| "–".into());
+            let (plain, styled) = search_state(episode);
+            let labels = items(episode);
+            let annotations = match labels.len() {
+                0 => palette.dim("–"),
+                1..=3 => labels.join(" "),
+                _ => format!(
+                    "{} {}",
+                    labels[..3].join(" "),
+                    palette.dim(&format!("+{}", labels.len() - 3))
+                ),
+            };
+            writeln!(
+                out,
+                "  {}   {:<8} {} {} {} {annotations}",
+                pad(&name, &palette.bold(&name), width),
+                length,
+                pad(&plain, &styled, 9),
+                pad("✓", &mark(station(episode, "screen_text")), 6),
+                pad("✓", &mark(station(episode, "transcript")), 8),
+            )?;
+            if detail {
+                writeln!(out, "    {}", palette.dim(&tilde(&episode.sidecar)))?;
+            }
+        }
+    }
+    let missing: Vec<&cerul::status::EpisodeStatus> = status
+        .episodes
+        .iter()
+        .filter(|episode| !episode.media_present)
+        .collect();
+    if !missing.is_empty() {
+        writeln!(
+            out,
+            "  {} {} video file{} moved away; their annotations are still here",
+            palette.warn("!"),
+            missing.len(),
+            if missing.len() == 1 { "" } else { "s" }
+        )?;
+    }
+    if let Some(failed) = status
+        .episodes
+        .iter()
+        .flat_map(|episode| &episode.embeddings)
+        .find(|state| !state.complete && state.error.is_some())
+    {
+        writeln!(
+            out,
+            "  {} search index incomplete: {}",
+            palette.warn("!"),
+            failed.error.as_deref().unwrap_or_default()
         )?;
     }
     writeln!(out)?;
-    writeln!(out, "{}", palette.bold("Models"))?;
     let dims = models
         .embedding_dims
         .map(|d| format!(" ({d}d)"))
         .unwrap_or_default();
-    writeln!(
-        out,
-        "  Gemini   search {}{}   ·   speech & vision {}",
-        models.embedding, dims, models.transcription
-    )?;
     let check = if probed {
         let reachable = |name: &str| match status.capabilities.get(name) {
             Some(Some(true)) => palette.ok("ok"),
@@ -786,31 +982,114 @@ pub fn status(
             reachable("vision")
         )
     } else {
-        palette.dim("not checked · run cerul status --providers to verify")
+        palette.dim("endpoints not checked · cerul status --providers verifies them")
     };
-    writeln!(
+    let ocr = match status.capabilities.get("ocr") {
+        Some(Some(true)) => "OCR runs locally",
+        _ => "OCR unavailable",
+    };
+    facts(
         out,
-        "           {}   ·   {check}",
-        models.key.summary(palette)
+        palette,
+        &[
+            (
+                "Models",
+                format!(
+                    "{}   {}{dims} · {} · {}",
+                    models.key.provider,
+                    models.embedding,
+                    models.vision,
+                    models.key.summary(palette)
+                ),
+            ),
+            ("", check),
+            (
+                "Storage",
+                format!(
+                    "sidecars beside each video · {} vector space{} · {ocr}",
+                    status.spaces.len(),
+                    if status.spaces.len() == 1 { "" } else { "s" }
+                ),
+            ),
+        ],
     )?;
     for (name, provider) in &status.providers {
         if let Some(error) = &provider.error {
-            writeln!(out, "           {} {name}: {error}", palette.warn("!"))?;
+            writeln!(out, "  {} {name}: {error}", palette.warn("!"))?;
         }
     }
-    writeln!(out)?;
-    let ocr = match status.capabilities.get("ocr") {
-        Some(Some(true)) => "screen text OCR runs locally",
-        _ => "screen text OCR unavailable",
-    };
+    if !status.episodes.is_empty() && !detail {
+        writeln!(out)?;
+        writeln!(
+            out,
+            "{}",
+            palette.dim("cerul status <path> for files · add --timeline to read the annotations")
+        )?;
+    }
+    Ok(())
+}
+
+/// Where the agent skill can go, or where it just went. Read-only until asked.
+pub fn skill(
+    out: &mut dyn Write,
+    palette: &Palette,
+    installed: Option<&Path>,
+    planned: Option<&Path>,
+    targets: &BTreeMap<String, PathBuf>,
+) -> io::Result<()> {
+    if let Some(path) = installed {
+        writeln!(
+            out,
+            "{} Wrote {}   {}",
+            palette.ok("✓"),
+            tilde(path),
+            palette.dim(&format!("cerul {}", env!("CARGO_PKG_VERSION")))
+        )?;
+        writeln!(out)?;
+        return writeln!(
+            out,
+            "{}",
+            palette.dim("Start a new agent session so it picks the skill up.")
+        );
+    }
+    if let Some(path) = planned {
+        writeln!(
+            out,
+            "{} would write {}",
+            palette.bold("Dry run:"),
+            tilde(path)
+        )?;
+        return Ok(());
+    }
     writeln!(
         out,
-        "{}",
-        palette.dim(&format!(
-            "Storage  indexes live beside your videos (*.cerul) · {} vector space{} cached · {ocr}",
-            status.spaces.len(),
-            if status.spaces.len() == 1 { "" } else { "s" }
-        ))
+        "{}   {}",
+        palette.bold("Agent skill"),
+        palette.dim("teaches a coding agent to drive cerul through --json")
+    )?;
+    writeln!(out)?;
+    let width = targets
+        .keys()
+        .map(|name| measure_text_width(name))
+        .max()
+        .unwrap_or(0);
+    for (name, path) in targets {
+        let pad = " ".repeat(width - measure_text_width(name) + 3);
+        let state = if path.is_file() {
+            palette.ok("installed")
+        } else {
+            palette.dim("not installed")
+        };
+        writeln!(out, "  {name}{pad}{state}   {}", palette.dim(&tilde(path)))?;
+    }
+    next_block(
+        out,
+        palette,
+        &[
+            ("cerul skill --install claude", "write it for that agent"),
+            ("cerul skill --dir ./skills", "write it anywhere else"),
+            ("cerul skill --print", "read it, or pipe it somewhere"),
+        ],
     )
 }
 
@@ -1003,14 +1282,19 @@ pub fn index(
         )?;
     }
     if ready > 0 {
-        writeln!(out)?;
-        writeln!(out, "{}", palette.bold("Try"))?;
-        next_steps(
+        next_block(
             out,
             palette,
             &[
-                ("cerul search \"what you're looking for\"", "find moments"),
-                ("cerul search \"...\" --save ./clips", "export clips"),
+                (
+                    "cerul search \"what you're looking for\"",
+                    "find moments by meaning",
+                ),
+                (
+                    "cerul search --text \"exact words\"",
+                    "match screen text or speech",
+                ),
+                ("cerul status", "what is searchable and where it lives"),
             ],
         )?;
     }
@@ -1108,18 +1392,7 @@ pub fn search(
     }
     let columns = console::Term::stdout().size().1.clamp(60, 110) as usize;
     let body = columns.saturating_sub(12);
-    let separator = palette.dim("  ·  ");
-    writeln!(
-        out,
-        "🔍 {} for {subject}",
-        palette.bold(&format!(
-            "{} result{}",
-            report.hits.len(),
-            if report.hits.len() == 1 { "" } else { "s" }
-        ))
-    )?;
-    writeln!(out)?;
-    // One card per video: the same recording matched at several moments is one
+    // One block per video: the same recording matched at several moments is one
     // thing a person is looking at, not several unrelated results.
     let mut groups: Vec<(String, Vec<(usize, &search::Hit)>)> = Vec::new();
     for (index, hit) in report.hits.iter().enumerate() {
@@ -1133,7 +1406,21 @@ pub fn search(
             None => groups.push((key, vec![(index, hit)])),
         }
     }
-    let rule = |mark: &str| palette.dim(mark);
+    writeln!(
+        out,
+        "{} for {subject}   {}",
+        palette.bold(&format!(
+            "{} moment{}",
+            report.hits.len(),
+            if report.hits.len() == 1 { "" } else { "s" }
+        )),
+        palette.dim(&format!(
+            "in {} video{}",
+            groups.len(),
+            if groups.len() == 1 { "" } else { "s" }
+        ))
+    )?;
+    writeln!(out)?;
     for (_, moments) in &groups {
         let first = moments[0].1;
         let name = first
@@ -1145,43 +1432,29 @@ pub fn search(
             Some(path) => context.terminal.file_link(&palette.bold(&name), path),
             None => palette.bold(&name),
         };
-        let count = if moments.len() > 1 {
-            format!(
-                "{}{}",
-                separator,
-                palette.dim(&format!("{} moments", moments.len()))
-            )
-        } else {
-            String::new()
-        };
-        writeln!(out, "  {} {title}{count}", rule("┌"))?;
+        writeln!(out, "  {title}")?;
         for (index, hit) in moments {
-            writeln!(out, "  {}", rule("│"))?;
-            let mut meta = Vec::new();
+            let mut meta = vec![format!("{} → {}", clock(hit.start_us), clock(hit.end_us))];
+            // A similarity is a ranking score, not a probability that the moment
+            // is the one asked for, so it is never labelled a match percentage.
             if let Some(score) = hit.score {
-                meta.push(format!(
-                    "📊 {}",
-                    palette.ok(&format!("{:.0}% match", (score * 100.).clamp(0., 100.)))
-                ));
+                meta.push(format!("similarity {:.0}%", (score * 100.).clamp(0., 100.)));
+            } else if context.text {
+                meta.push("exact".into());
             }
-            meta.push(format!(
-                "🕐 {}",
-                palette.dim(&format!("{} → {}", clock(hit.start_us), clock(hit.end_us)))
-            ));
-            meta.push(format!("🎬 {}", palette.dim(kind_label(hit.matched))));
+            meta.push(kind_label(hit.matched).to_owned());
             writeln!(
                 out,
-                "  {}  {}  {}",
-                rule("│"),
+                "  {}  {}",
                 palette.cmd(&format!("[{}]", index + 1)),
-                meta.join(&separator).trim_end()
+                palette.dim(&meta.join("   "))
             )?;
             if let Some(preview) = hit
                 .preview
                 .as_deref()
                 .filter(|_| context.terminal.images.is_some())
             {
-                write!(out, "  {}       ", rule("│"))?;
+                write!(out, "       ")?;
                 if context.terminal.image(out, preview, 30, 8)? {
                     writeln!(out)?;
                 }
@@ -1195,53 +1468,28 @@ pub fn search(
                     last.push('…');
                 }
                 for line in lines {
-                    writeln!(
-                        out,
-                        "  {}      {}",
-                        rule("│"),
-                        palette.dim(&format!("\"{line}\""))
-                    )?;
+                    writeln!(out, "       {line}")?;
                 }
             }
             if let Some(path) = hit.media.as_deref() {
                 let (label, target) = context.player.open(path, hit.start_us);
-                writeln!(
-                    out,
-                    "  {}       🔗 {}",
-                    rule("│"),
-                    context.terminal.link(&palette.cmd(&label), &target)
-                )?;
+                if context.terminal.hyperlinks {
+                    writeln!(
+                        out,
+                        "       {}",
+                        context.terminal.link(&palette.cmd(&label), &target)
+                    )?;
+                }
             }
             if let Some(clip) = hit.clip.as_deref() {
                 writeln!(
                     out,
-                    "  {}       🎞 {}   {}",
-                    rule("│"),
+                    "       {}   {}",
                     context.terminal.file_link(&palette.cmd("Saved clip"), clip),
                     palette.dim(&tilde(clip))
                 )?;
             }
         }
-        match first.media.as_deref() {
-            Some(path) => writeln!(out, "  {} {}", rule("└"), palette.dim(&tilde(path)))?,
-            None => writeln!(out, "  {}", rule("└"))?,
-        }
-        writeln!(out)?;
-    }
-    if let Some((number, _)) = report
-        .hits
-        .iter()
-        .enumerate()
-        .find(|(_, hit)| hit.media.is_some())
-    {
-        writeln!(
-            out,
-            "{}",
-            palette.dim(&format!(
-                "Open a moment in your player: cerul open {}",
-                number + 1
-            ))
-        )?;
         writeln!(out)?;
     }
     if context.terminal.images.is_none() && report.hits.iter().any(|hit| hit.preview.is_some()) {
@@ -1252,7 +1500,6 @@ pub fn search(
                 "Still frames were saved but this terminal cannot draw them; iTerm2, Ghostty, Kitty, and WezTerm can."
             )
         )?;
-        writeln!(out)?;
     }
     if report
         .hits
@@ -1264,27 +1511,45 @@ pub fn search(
             "{}",
             palette.dim("Visual matches cover an index window (30s by default); re-index with --chunk 10s for finer moments.")
         )?;
-        writeln!(out)?;
     }
-    if let Some(directory) = &context.saved_to {
-        writeln!(
-            out,
-            "{} clip{} saved to {}",
-            report.hits.iter().filter(|h| h.clip.is_some()).count(),
-            if report.hits.len() == 1 { "" } else { "s" },
-            directory.display()
-        )?;
-    } else if let Some(query) = &context.query {
-        let flag = if context.text { " --text" } else { "" };
-        next_steps(
-            out,
-            palette,
-            &[(
-                &format!("cerul search{flag} \"{query}\" --save ./clips"),
+    let mut steps: Vec<(String, &str)> = Vec::new();
+    if let Some((number, _)) = report
+        .hits
+        .iter()
+        .enumerate()
+        .find(|(_, hit)| hit.media.is_some())
+    {
+        steps.push((
+            format!("cerul open {}", number + 1),
+            "play that moment in your player",
+        ));
+    }
+    match (&context.saved_to, &context.query) {
+        (Some(directory), _) => {
+            let saved = report.hits.iter().filter(|hit| hit.clip.is_some()).count();
+            writeln!(out)?;
+            writeln!(
+                out,
+                "{} clip{} saved to {}",
+                saved,
+                if saved == 1 { "" } else { "s" },
+                tilde(directory)
+            )?;
+        }
+        (None, Some(query)) => {
+            let flag = if context.text { " --text" } else { "" };
+            steps.push((
+                format!("cerul search{flag} {} --save ./clips", shell_quote(query)),
                 "save these moments as clips",
-            )],
-        )?;
+            ));
+        }
+        (None, None) => {}
     }
+    let steps: Vec<(&str, &str)> = steps
+        .iter()
+        .map(|(command, note)| (command.as_str(), *note))
+        .collect();
+    next_block(out, palette, &steps)?;
     Ok(())
 }
 
@@ -1356,85 +1621,381 @@ pub fn remove(
     writeln!(out, "{}", palette.dim(note))
 }
 
+/// The annotation receipt: what exists now, where it is, and what to run next.
+/// A checkpoint on disk is not an annotation, so only published modules get a
+/// record count and a path here.
 pub fn annotate(
     out: &mut dyn Write,
     palette: &Palette,
     report: &annotate::pipeline::Report,
     names: &BTreeMap<String, PathBuf>,
+    retry: Option<&str>,
 ) -> io::Result<()> {
-    if report.dry_run {
-        writeln!(out, "{} nothing was written.", palette.bold("Dry run:"))?;
-    }
     if report.modules.is_empty() && report.writebacks.is_empty() {
         writeln!(out, "Nothing to annotate.")?;
         return Ok(());
     }
+    if report.dry_run {
+        writeln!(
+            out,
+            "{} nothing was written and no model was called.",
+            palette.bold("Dry run:")
+        )?;
+        writeln!(out)?;
+    }
+    // One block per input: the same recording labelled four ways is one thing a
+    // person is looking at, not four unrelated results.
+    let mut groups: Vec<(&str, Vec<&annotate::pipeline::ModuleResult>)> = Vec::new();
     for module in &report.modules {
-        let name = names
-            .get(&module.episode)
-            .map(|p| file_name(p))
-            .unwrap_or_else(|| module.episode.clone());
-        let label = station_label(&module.annotation);
-        match (&module.error, module.complete) {
-            (None, true) => writeln!(
-                out,
-                "{} {}  {label}  {}",
-                palette.ok("✓"),
-                palette.bold(&name),
-                palette.dim(&format!("{} records", module.records))
-            )?,
-            (None, false) => writeln!(
-                out,
-                "{} {}  {label}  {}",
-                palette.warn("!"),
-                palette.bold(&name),
-                palette.dim(&format!("incomplete, {} records so far", module.records))
-            )?,
-            (Some(error), _) => {
-                writeln!(out, "{} {}  {label}", palette.err("✗"), palette.bold(&name))?;
-                writeln!(out, "    {error}")?;
+        match groups
+            .iter_mut()
+            .find(|(episode, _)| *episode == module.episode.as_str())
+        {
+            Some((_, modules)) => modules.push(module),
+            None => groups.push((module.episode.as_str(), vec![module])),
+        }
+    }
+    let mut written = false;
+    for (episode, modules) in &groups {
+        // Episodes of one dataset share their MP4 shards, so a media file name
+        // would label two different results identically. The dataset and the
+        // episode index are what tell them apart.
+        let source = &modules[0].source;
+        let name = match modules[0].dataset {
+            true => format!(
+                "{} · episode {}",
+                file_name(source),
+                episode.rsplit('/').next().unwrap_or(episode)
+            ),
+            false if source.as_os_str().is_empty() => names
+                .get(*episode)
+                .map(|media| file_name(media))
+                .unwrap_or_else(|| (*episode).to_string()),
+            false => file_name(source),
+        };
+        if written {
+            writeln!(out)?;
+        }
+        written = true;
+        if report.dry_run {
+            let items = modules
+                .iter()
+                .map(|module| item_name(&module.annotation))
+                .collect::<Vec<_>>()
+                .join(" · ");
+            writeln!(out, "  {}   {}", palette.bold(&name), palette.dim(&items))?;
+            continue;
+        }
+        let published = modules.iter().filter(|module| module.complete).count();
+        let (mark, title) = match (published, published == modules.len()) {
+            (_, true) => (palette.ok("✓"), format!("Annotated {name}")),
+            (0, _) => (palette.err("✗"), format!("Could not annotate {name}")),
+            _ => (palette.warn("!"), format!("Annotated {name} partially")),
+        };
+        writeln!(out, "{mark} {}", palette.bold(&title))?;
+        writeln!(out)?;
+        // Cameras of one episode share a file name, so the stream has to appear
+        // whenever more than one of them was annotated.
+        let streams: BTreeSet<&str> = modules.iter().map(|m| m.stream.as_str()).collect();
+        let label = |module: &annotate::pipeline::ModuleResult| {
+            if streams.len() > 1 {
+                format!("{} · {}", module.stream, item_name(&module.annotation))
+            } else {
+                item_name(&module.annotation).to_owned()
+            }
+        };
+        let width = modules
+            .iter()
+            .map(|module| measure_text_width(&label(module)))
+            .max()
+            .unwrap_or(0);
+        let counts: Vec<String> = modules
+            .iter()
+            .map(|module| {
+                if module.complete {
+                    format!(
+                        "{} record{}",
+                        module.records,
+                        if module.records == 1 { "" } else { "s" }
+                    )
+                } else {
+                    String::new()
+                }
+            })
+            .collect();
+        let count_width = counts
+            .iter()
+            .map(|count| measure_text_width(count))
+            .max()
+            .unwrap_or(0);
+        let mixed = published != modules.len();
+        for (module, count) in modules.iter().zip(&counts) {
+            let glyph = if mixed {
+                let mark = match (&module.error, module.complete) {
+                    (_, true) => palette.ok("✓"),
+                    (Some(_), _) => palette.err("✗"),
+                    _ => palette.dim("·"),
+                };
+                format!("{mark} ")
+            } else {
+                String::new()
+            };
+            let text = label(module);
+            let pad = " ".repeat(width - measure_text_width(&text) + 3);
+            match (&module.error, module.complete) {
+                (_, true) => {
+                    let gap = " ".repeat(count_width - measure_text_width(count) + 3);
+                    let path = module
+                        .path
+                        .as_deref()
+                        .map(tilde)
+                        .unwrap_or_else(|| "published".into());
+                    writeln!(
+                        out,
+                        "  {glyph}{text}{pad}{count}{gap}{}",
+                        palette.dim(&path)
+                    )?;
+                }
+                (Some(error), _) => writeln!(
+                    out,
+                    "  {glyph}{text}{pad}{}",
+                    palette.warn(&format!("stopped · {error}"))
+                )?,
+                (None, false) => {
+                    writeln!(out, "  {glyph}{text}{pad}{}", palette.dim("not started"))?
+                }
             }
         }
     }
     for writeback in &report.writebacks {
+        if written {
+            writeln!(out)?;
+        }
+        written = true;
         match &writeback.error {
-            None => writeln!(
-                out,
-                "{} wrote LeRobot dataset {}",
-                palette.ok("✓"),
-                tilde(&writeback.destination)
-            )?,
+            None => {
+                writeln!(
+                    out,
+                    "{} {}",
+                    palette.ok("✓"),
+                    palette.bold(&format!(
+                        "Wrote LeRobot dataset {}",
+                        file_name(&writeback.destination)
+                    ))
+                )?;
+                writeln!(out, "  {}", palette.dim(&tilde(&writeback.destination)))?;
+            }
             Some(error) => {
                 writeln!(
                     out,
-                    "{} LeRobot writeback failed for {}",
+                    "{} {}",
                     palette.err("✗"),
-                    tilde(&writeback.source)
+                    palette.bold(&format!(
+                        "LeRobot writeback failed for {}",
+                        file_name(&writeback.source)
+                    ))
                 )?;
-                writeln!(out, "    {error}")?;
+                writeln!(out, "  {error}")?;
             }
         }
     }
+    if !report.dry_run {
+        let media = report
+            .modules
+            .iter()
+            .find(|module| module.complete)
+            .and_then(|module| names.get(&module.episode));
+        let mut steps: Vec<(String, &str)> = Vec::new();
+        if let Some(path) = media {
+            steps.push((
+                format!("cerul status {} --timeline", shell_path(path)),
+                "read the labels in order",
+            ));
+        }
+        if report
+            .modules
+            .iter()
+            .any(|module| module.complete && item_name(&module.annotation) == "event")
+        {
+            steps.push((
+                "cerul search --filter 'semantic.event.verb=grasp'".into(),
+                "find one action across videos",
+            ));
+        }
+        let steps: Vec<(&str, &str)> = steps
+            .iter()
+            .map(|(command, note)| (command.as_str(), *note))
+            .collect();
+        next_block(out, palette, &steps)?;
+    }
     if report.partial {
+        writeln!(out)?;
+        let anything = report.modules.iter().any(|module| module.complete);
+        match retry {
+            Some(command) => {
+                // Promising that finished work is reused is only reassuring when
+                // something actually finished.
+                writeln!(
+                    out,
+                    "{}",
+                    palette.dim(match anything {
+                        true => "Finished windows are saved and will be reused. Continue with:",
+                        false => "Nothing was published. After fixing the problem above:",
+                    })
+                )?;
+                writeln!(out, "  {}", palette.cmd(command))?;
+            }
+            None => writeln!(
+                out,
+                "{}",
+                palette
+                    .dim("Finished windows are saved; re-run the same command to resume the rest.")
+            )?,
+        }
+    }
+    if !report.dry_run && report.modules.iter().any(|module| module.complete) {
         writeln!(out)?;
         writeln!(
             out,
             "{}",
-            palette.dim("Finished windows are saved; re-run the same command to resume the rest.")
+            palette.dim("Labels are model-generated; review them before training on them.")
         )?;
+    }
+    Ok(())
+}
+
+/// Published annotation records in time order: the cheapest way to judge whether
+/// a run produced anything worth keeping, without opening a JSONL file.
+pub fn timeline(
+    out: &mut dyn Write,
+    palette: &Palette,
+    timeline: &cerul::status::Timeline,
+    kind: Option<&str>,
+) -> io::Result<()> {
+    if timeline.episodes.is_empty() {
+        // Screen text and speech are annotations too, but a timeline is for the
+        // labels a person asked a model for, so say which kind is missing.
+        writeln!(out, "No semantic annotations here yet.")?;
+        return next_block(
+            out,
+            palette,
+            &[(
+                "cerul annotate ./video.mp4 --semantic subtask,event,interaction,state",
+                "label actions in a video",
+            )],
+        );
+    }
+    for (position, episode) in timeline.episodes.iter().enumerate() {
+        if position > 0 {
+            writeln!(out)?;
+        }
+        let items = episode
+            .annotations
+            .iter()
+            .map(|name| item_name(name))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let length = episode
+            .duration_us
+            .map(|us| format!("  {}", clock(us)))
+            .unwrap_or_default();
+        writeln!(
+            out,
+            "{}{length}  {}",
+            palette.bold(&file_name(&episode.media)),
+            palette.dim(&format!("·  {items}  ·  {}", tilde(&episode.sidecar)))
+        )?;
+        writeln!(out)?;
+        if episode.entries.is_empty() {
+            writeln!(
+                out,
+                "  {}",
+                palette.dim(&match kind {
+                    Some(kind) => format!("no {kind} records"),
+                    None => "no records".into(),
+                })
+            )?;
+            continue;
+        }
+        let times: Vec<String> = episode
+            .entries
+            .iter()
+            .map(|entry| {
+                // A moment and a span are different facts; only a span gets a range.
+                if entry.end_us > entry.start_us {
+                    format!("{} – {}", clock(entry.start_us), clock(entry.end_us))
+                } else {
+                    clock(entry.start_us)
+                }
+            })
+            .collect();
+        let time_width = times
+            .iter()
+            .map(|t| measure_text_width(t))
+            .max()
+            .unwrap_or(0);
+        let name_width = episode
+            .entries
+            .iter()
+            .map(|entry| measure_text_width(item_name(&entry.annotation)))
+            .max()
+            .unwrap_or(0);
+        for (entry, time) in episode.entries.iter().zip(&times) {
+            let name = item_name(&entry.annotation);
+            writeln!(
+                out,
+                "  {time:>time_width$}   {}{}{}",
+                palette.cmd(name),
+                " ".repeat(name_width - measure_text_width(name) + 3),
+                entry.summary
+            )?;
+        }
+        if episode.total > episode.entries.len() {
+            writeln!(out)?;
+            writeln!(
+                out,
+                "{}",
+                palette.dim(&format!(
+                    "showing {} of {} records · --limit {} for more{}",
+                    episode.entries.len(),
+                    episode.total,
+                    episode.total.min(1000),
+                    if kind.is_some() {
+                        ""
+                    } else {
+                        " · --type event for one kind"
+                    }
+                ))
+            )?;
+        }
     }
     Ok(())
 }
 
 /// Human error line plus a hint on how to recover.
 pub fn error(palette: &Palette, code: u8, message: &str, hint: Option<&str>) -> String {
-    let mut text = format!("{} {message}", palette.err("error:"));
+    // What went wrong, then how to get out of it, then the code a script reads.
+    // Cancelling is a choice somebody made, so it is not painted as a failure.
+    let category = match code {
+        2 => "invalid arguments or configuration",
+        3 => "unavailable dependency or capability",
+        5 => "cancelled",
+        6 => "partial result",
+        _ => "execution failure",
+    };
+    let mark = if code == 5 {
+        palette.warn("!")
+    } else {
+        palette.err("✗")
+    };
+    let mut text = format!("{mark} {message}");
     if let Some(hint) = hint {
-        text.push_str(&format!("\n  {} {hint}", palette.dim("hint:")));
+        text.push_str(&format!("\n  {}", palette.cmd(hint)));
     }
-    if code == 5 {
-        text = format!("{} {message}", palette.warn("cancelled:"));
-    }
+    text.push_str(&format!(
+        "\n  {}",
+        palette.dim(&format!("exit {code} · {category}"))
+    ));
     text
 }
 
@@ -1448,6 +2009,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut status = cerul::status::inspect(dir.path(), None).unwrap();
         status.episodes.push(cerul::status::EpisodeStatus {
+            duration_us: Some(150_000_000),
             episode_id: "demo/0".into(),
             media: PathBuf::from("/videos/demo.mp4"),
             sidecar: PathBuf::from("/videos/demo.mp4.cerul"),
@@ -1478,8 +2040,15 @@ mod tests {
         assert!(text.contains("key saved"));
         assert!(text.contains("cerul annotate ./video.mp4 --semantic"));
         assert!(text.contains("cerul annotate --help"));
+        // The overview is a table; the files belong to the view a person asked
+        // for by naming a path.
         let mut out = Vec::new();
-        super::status(&mut out, &palette, &status, &models, false).unwrap();
+        super::status(&mut out, &palette, &status, &models, false, false).unwrap();
+        let overview = String::from_utf8(out).unwrap();
+        assert!(overview.contains("demo.mp4"), "{overview}");
+        assert!(!overview.contains("/videos/demo.mp4.cerul"), "{overview}");
+        let mut out = Vec::new();
+        super::status(&mut out, &palette, &status, &models, false, true).unwrap();
         assert!(
             String::from_utf8(out)
                 .unwrap()
@@ -1526,11 +2095,14 @@ mod tests {
         assert!(!text.contains("b52ef6450d471af5"), "{text}");
         assert!(!text.contains("0.74"), "{text}");
         assert!(text.contains("a demo.mp4"), "{text}");
-        assert!(text.contains("74% match"), "{text}");
+        assert!(text.contains("similarity 74%"), "{text}");
         assert!(text.contains("00:12 → 00:19"), "{text}");
         assert!(text.contains("speech"), "{text}");
         assert!(text.contains("perfecting this harness"), "{text}");
-        assert!(text.contains("Open video"), "{text}");
+        // Without hyperlink support a label with no URL behind it is noise; the
+        // numbered result and `cerul open` are what actually play the moment.
+        assert!(!text.contains("Open video"), "{text}");
+        assert!(text.contains("cerul open 1"), "{text}");
         // No colour, hyperlink, or image control sequences without support.
         assert!(!text.contains('\u{1b}'), "{text}");
     }
@@ -1558,8 +2130,10 @@ mod tests {
         let mut out = Vec::new();
         search(&mut out, &Palette::new(false), &report, &context).unwrap();
         let text = String::from_utf8(out).unwrap();
-        assert_eq!(text.matches("a demo.mp4").count(), 2, "{text}");
+        // Two moments, one heading: the file is named once.
+        assert_eq!(text.matches("a demo.mp4").count(), 1, "{text}");
         assert!(text.contains("2 moments"), "{text}");
+        assert!(text.contains("in 1 video"), "{text}");
         assert!(text.contains("[1]") && text.contains("[2]"), "{text}");
         assert!(text.contains("01:30 → 01:36"), "{text}");
         assert!(text.contains("cerul open 1"), "{text}");
@@ -1589,6 +2163,185 @@ mod tests {
         assert_eq!(
             Player::System.open(Path::new("/videos/a demo.mp4"), 12_500_000),
             ("Open video".into(), "file:///videos/a%20demo.mp4".into())
+        );
+    }
+
+    fn module(item: &str, records: usize, error: Option<&str>) -> annotate::pipeline::ModuleResult {
+        annotate::pipeline::ModuleResult {
+            episode: "demo/0".into(),
+            stream: "primary".into(),
+            annotation: format!("semantic.{item}"),
+            records,
+            complete: error.is_none(),
+            error: error.map(str::to_owned),
+            source: PathBuf::from("/videos/demo.mp4"),
+            dataset: false,
+            path: error
+                .is_none()
+                .then(|| PathBuf::from(format!("/videos/demo.mp4.cerul/semantic.{item}.jsonl"))),
+        }
+    }
+
+    #[test]
+    fn the_annotation_receipt_names_every_published_file_and_what_to_run_next() {
+        let report = annotate::pipeline::Report {
+            modules: vec![module("subtask", 12, None), module("event", 18, None)],
+            writebacks: Vec::new(),
+            partial: false,
+            dry_run: false,
+        };
+        let names = BTreeMap::from([("demo/0".to_owned(), PathBuf::from("/videos/demo.mp4"))]);
+        let mut out = Vec::new();
+        annotate(&mut out, &Palette::new(false), &report, &names, None).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("Annotated demo.mp4"), "{text}");
+        // The episode hash is an internal name; a person needs the file.
+        assert!(!text.contains("demo/0"), "{text}");
+        assert!(text.contains("subtask"), "{text}");
+        assert!(text.contains("12 records"), "{text}");
+        assert!(
+            text.contains("/videos/demo.mp4.cerul/semantic.event.jsonl"),
+            "{text}"
+        );
+        assert!(
+            text.contains("cerul status /videos/demo.mp4 --timeline"),
+            "{text}"
+        );
+        assert!(text.contains("cerul search --filter"), "{text}");
+        assert!(text.contains("review them before training"), "{text}");
+    }
+
+    #[test]
+    fn a_partial_run_separates_published_work_from_the_command_that_continues_it() {
+        let report = annotate::pipeline::Report {
+            modules: vec![
+                module("subtask", 12, None),
+                module("event", 0, Some("gemini rate limit (429)")),
+                annotate::pipeline::ModuleResult {
+                    records: 0,
+                    complete: false,
+                    ..module("state", 0, None)
+                },
+            ],
+            writebacks: Vec::new(),
+            partial: true,
+            dry_run: false,
+        };
+        let names = BTreeMap::from([("demo/0".to_owned(), PathBuf::from("/videos/demo.mp4"))]);
+        let mut out = Vec::new();
+        let retry = "cerul annotate /videos/demo.mp4 --semantic subtask,event,state --rpm 6";
+        annotate(&mut out, &Palette::new(false), &report, &names, Some(retry)).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("partially"), "{text}");
+        assert!(text.contains("12 records"), "{text}");
+        assert!(text.contains("stopped · gemini rate limit (429)"), "{text}");
+        assert!(text.contains("not started"), "{text}");
+        assert!(text.contains(retry), "{text}");
+        // Recomputing would throw away the windows that did finish.
+        assert!(!text.contains("--recompute"), "{text}");
+    }
+
+    fn record(
+        start_us: i64,
+        end_us: i64,
+        fields: &[(&str, serde_json::Value)],
+    ) -> cerul::annotations::Record {
+        cerul::annotations::Record {
+            id: format!("r-{start_us}"),
+            start_us,
+            end_us,
+            confidence: None,
+            fields: fields
+                .iter()
+                .map(|(key, value)| ((*key).to_owned(), value.clone()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn the_timeline_orders_records_and_writes_each_kind_in_its_own_words() {
+        let entries = [
+            (
+                "semantic.subtask",
+                record(0, 14_000_000, &[("text", "reach for the cup".into())]),
+            ),
+            (
+                "semantic.event",
+                record(
+                    3_000_000,
+                    3_000_000,
+                    &[
+                        ("verb", "grasp".into()),
+                        ("objects", serde_json::json!(["cup"])),
+                    ],
+                ),
+            ),
+            (
+                "semantic.state",
+                record(
+                    20_000_000,
+                    20_000_000,
+                    &[
+                        ("object", "cup".into()),
+                        ("attribute", "location".into()),
+                        ("before", "on table".into()),
+                        ("after", "in hand".into()),
+                    ],
+                ),
+            ),
+        ];
+        let timeline = cerul::status::Timeline {
+            episodes: vec![cerul::status::TimelineEpisode {
+                episode_id: "demo/0".into(),
+                media: PathBuf::from("/videos/demo.mp4"),
+                sidecar: PathBuf::from("/videos/demo.mp4.cerul"),
+                duration_us: Some(150_000_000),
+                annotations: vec!["semantic.subtask".into(), "semantic.event".into()],
+                total: 53,
+                entries: entries
+                    .iter()
+                    .map(|(annotation, record)| cerul::status::TimelineEntry {
+                        episode: "demo/0".into(),
+                        stream: "primary".into(),
+                        annotation: (*annotation).to_owned(),
+                        start_us: record.start_us,
+                        end_us: record.end_us,
+                        summary: cerul::status::summarize_record(annotation, record),
+                        record: record.clone(),
+                    })
+                    .collect(),
+            }],
+        };
+        let mut out = Vec::new();
+        super::timeline(&mut out, &Palette::new(false), &timeline, None).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("demo.mp4  02:30"), "{text}");
+        assert!(text.contains("00:00 – 00:14   subtask"), "{text}");
+        assert!(text.contains("reach for the cup"), "{text}");
+        // A moment has one time, not a range that starts and ends together.
+        assert!(
+            text.contains("00:03") && !text.contains("00:03 – 00:03"),
+            "{text}"
+        );
+        assert!(text.contains("grasp cup"), "{text}");
+        assert!(
+            text.contains("cup · location: on table → in hand"),
+            "{text}"
+        );
+        assert!(text.contains("showing 3 of 53 records"), "{text}");
+    }
+
+    #[test]
+    fn a_command_survives_being_copied_out_of_the_receipt() {
+        assert_eq!(shell_quote("./demo.mp4"), "./demo.mp4");
+        assert_eq!(
+            shell_quote("my videos/a demo.mp4"),
+            "'my videos/a demo.mp4'"
+        );
+        assert_eq!(shell_quote("it's here.mp4"), r"'it'\''s here.mp4'");
+        assert_eq!(
+            shell_command(&["cerul".into(), "annotate".into(), "a b.mp4".into()]),
+            "cerul annotate 'a b.mp4'"
         );
     }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -1955,19 +1955,30 @@ pub fn timeline(
             .map(|t| measure_text_width(t))
             .max()
             .unwrap_or(0);
+        // Cameras of one episode produce the same kinds of record at the same
+        // times, so the stream has to appear once more than one was annotated.
+        let streams: BTreeSet<&str> = episode
+            .entries
+            .iter()
+            .map(|entry| entry.stream.as_str())
+            .collect();
+        let label = |entry: &cerul::status::TimelineEntry| match streams.len() > 1 {
+            true => format!("{} · {}", entry.stream, item_name(&entry.annotation)),
+            false => item_name(&entry.annotation).to_owned(),
+        };
         let name_width = episode
             .entries
             .iter()
-            .map(|entry| measure_text_width(item_name(&entry.annotation)))
+            .map(|entry| measure_text_width(&label(entry)))
             .max()
             .unwrap_or(0);
         for (entry, time) in episode.entries.iter().zip(&times) {
-            let name = item_name(&entry.annotation);
+            let name = label(entry);
             writeln!(
                 out,
                 "  {time:>time_width$}   {}{}{}",
-                palette.cmd(name),
-                " ".repeat(name_width - measure_text_width(name) + 3),
+                palette.cmd(&name),
+                " ".repeat(name_width - measure_text_width(&name) + 3),
                 entry.summary
             )?;
         }
@@ -2352,6 +2363,53 @@ mod tests {
             "{text}"
         );
         assert!(text.contains("showing 3 of 53 records"), "{text}");
+    }
+
+    #[test]
+    fn a_timeline_of_several_cameras_says_which_camera_each_record_came_from() {
+        let entry = |stream: &str, start_us: i64| cerul::status::TimelineEntry {
+            episode: "d7f0/000000".into(),
+            stream: stream.into(),
+            annotation: "semantic.event".into(),
+            start_us,
+            end_us: start_us,
+            summary: "grasp cup".into(),
+            record: record(start_us, start_us, &[("verb", "grasp".into())]),
+        };
+        let mut episode = cerul::status::TimelineEpisode {
+            episode_id: "d7f0/000000".into(),
+            media: PathBuf::from("/data/egodemo/videos/front/file-000.mp4"),
+            sidecar: PathBuf::from("/data/egodemo/.cerul/episodes/0"),
+            duration_us: Some(8_000_000),
+            annotations: vec!["semantic.event".into()],
+            total: 2,
+            entries: vec![
+                entry("observation.images.front", 3_000_000),
+                entry("observation.images.wrist", 3_000_000),
+            ],
+        };
+        let render = |episodes| {
+            let mut out = Vec::new();
+            super::timeline(
+                &mut out,
+                &Palette::new(false),
+                &cerul::status::Timeline { episodes },
+                None,
+            )
+            .unwrap();
+            String::from_utf8(out).unwrap()
+        };
+        // Two cameras record the same kind of thing at the same time, so the
+        // lines are indistinguishable without the camera.
+        let text = render(vec![episode.clone()]);
+        assert!(text.contains("observation.images.front · event"), "{text}");
+        assert!(text.contains("observation.images.wrist · event"), "{text}");
+        // One camera needs no column repeating its name on every line.
+        episode.entries.truncate(1);
+        episode.total = 1;
+        let text = render(vec![episode]);
+        assert!(!text.contains("observation.images.front ·"), "{text}");
+        assert!(text.contains("event"), "{text}");
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -1068,6 +1068,21 @@ pub fn skill(
         palette.dim("teaches a coding agent to drive cerul through --json")
     )?;
     writeln!(out)?;
+    if targets.is_empty() {
+        writeln!(
+            out,
+            "  {}",
+            palette.dim("HOME is not set, so no agent's own directory is known here.")
+        )?;
+        return next_block(
+            out,
+            palette,
+            &[
+                ("cerul skill --dir ./skills", "write it to a directory"),
+                ("cerul skill --print", "read it, or pipe it somewhere"),
+            ],
+        );
+    }
     let width = targets
         .keys()
         .map(|name| measure_text_width(name))
@@ -1800,13 +1815,19 @@ pub fn annotate(
         }
     }
     if !report.dry_run {
+        // A dataset's episodes share their video shards, so pointing at one
+        // shard would read back a fraction of what this run produced. The input
+        // the person named is what covers all of it.
         let media = report
             .modules
             .iter()
             .find(|module| module.complete)
-            .and_then(|module| names.get(&module.episode));
+            .map(|module| match module.dataset {
+                true => Some(&module.source),
+                false => names.get(&module.episode).or(Some(&module.source)),
+            });
         let mut steps: Vec<(String, &str)> = Vec::new();
-        if let Some(path) = media {
+        if let Some(Some(path)) = media {
             steps.push((
                 format!("cerul status {} --timeline", shell_path(path)),
                 "read the labels in order",
@@ -2189,6 +2210,7 @@ mod tests {
             writebacks: Vec::new(),
             partial: false,
             dry_run: false,
+            retry: None,
         };
         let names = BTreeMap::from([("demo/0".to_owned(), PathBuf::from("/videos/demo.mp4"))]);
         let mut out = Vec::new();
@@ -2226,6 +2248,7 @@ mod tests {
             writebacks: Vec::new(),
             partial: true,
             dry_run: false,
+            retry: None,
         };
         let names = BTreeMap::from([("demo/0".to_owned(), PathBuf::from("/videos/demo.mp4"))]);
         let mut out = Vec::new();
@@ -2329,6 +2352,45 @@ mod tests {
             "{text}"
         );
         assert!(text.contains("showing 3 of 53 records"), "{text}");
+    }
+
+    #[test]
+    fn a_dataset_receipt_points_at_the_dataset_rather_than_a_shared_shard() {
+        let module = annotate::pipeline::ModuleResult {
+            episode: "d7f0/000001".into(),
+            stream: "observation.images.front".into(),
+            annotation: "semantic.subtask".into(),
+            records: 6,
+            complete: true,
+            error: None,
+            source: PathBuf::from("/data/egodemo"),
+            dataset: true,
+            path: Some(PathBuf::from(
+                "/data/egodemo/.cerul/episodes/1/semantic.subtask.jsonl",
+            )),
+        };
+        let report = annotate::pipeline::Report {
+            modules: vec![module],
+            writebacks: Vec::new(),
+            partial: false,
+            dry_run: false,
+            retry: None,
+        };
+        // Every episode of a dataset shares this shard, so the registry's media
+        // path would read back one episode out of the run.
+        let names = BTreeMap::from([(
+            "d7f0/000001".to_owned(),
+            PathBuf::from("/data/egodemo/videos/observation.images.front/chunk-000/file-000.mp4"),
+        )]);
+        let mut out = Vec::new();
+        annotate(&mut out, &Palette::new(false), &report, &names, None).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("egodemo · episode 000001"), "{text}");
+        assert!(
+            text.contains("cerul status /data/egodemo --timeline"),
+            "{text}"
+        );
+        assert!(!text.contains("file-000.mp4"), "{text}");
     }
 
     #[test]

--- a/src/status.rs
+++ b/src/status.rs
@@ -33,6 +33,9 @@ pub struct EpisodeStatus {
     pub media: PathBuf,
     pub sidecar: PathBuf,
     pub media_present: bool,
+    /// Episode-relative length of the primary stream, read from the sidecar.
+    #[serde(default)]
+    pub duration_us: Option<i64>,
     pub annotations: Vec<String>,
     pub embedding_spaces: Vec<String>,
     pub embeddings: Vec<EmbeddingStatus>,
@@ -68,6 +71,232 @@ fn file_names(directory: &Path, suffix: &str) -> Result<Vec<String>> {
     }
     names.sort();
     Ok(names)
+}
+
+/// One published annotation record, reduced to what a person reads in a list.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TimelineEntry {
+    pub episode: String,
+    pub stream: String,
+    /// Full annotation name, for example `semantic.subtask`.
+    pub annotation: String,
+    pub start_us: i64,
+    pub end_us: i64,
+    /// The record's own fields written as one line. The record itself stays
+    /// authoritative; this is a reading aid, not a new data format.
+    pub summary: String,
+    pub record: crate::annotations::Record,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TimelineEpisode {
+    pub episode_id: String,
+    pub media: PathBuf,
+    pub sidecar: PathBuf,
+    pub duration_us: Option<i64>,
+    /// Annotation names present for this episode, in file order.
+    pub annotations: Vec<String>,
+    /// Records that matched the selection before `limit` was applied.
+    pub total: usize,
+    pub entries: Vec<TimelineEntry>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct Timeline {
+    pub episodes: Vec<TimelineEpisode>,
+}
+#[derive(Debug, Clone)]
+pub struct TimelineOptions {
+    /// Semantic item or full annotation name; `None` reads every published item.
+    pub kind: Option<String>,
+    pub limit: usize,
+}
+
+/// Writes one record as a line, using the fields that item actually defines.
+/// An unknown item falls back to its own JSON so nothing is silently dropped.
+pub fn summarize_record(annotation: &str, record: &crate::annotations::Record) -> String {
+    let text = |key: &str| {
+        record
+            .fields
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("")
+            .to_owned()
+    };
+    let item = annotation
+        .rsplit('/')
+        .next()
+        .unwrap_or(annotation)
+        .strip_prefix("semantic.")
+        .unwrap_or(annotation);
+    match item {
+        "task" | "subtask" => text("text"),
+        "event" => {
+            let objects = record
+                .fields
+                .get("objects")
+                .and_then(serde_json::Value::as_array)
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(serde_json::Value::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .unwrap_or_default();
+            let outcome = text("outcome");
+            let mut line = text("verb");
+            if !objects.is_empty() {
+                line.push(' ');
+                line.push_str(&objects);
+            }
+            if !outcome.is_empty() {
+                line.push_str(" → ");
+                line.push_str(&outcome);
+            }
+            line
+        }
+        "interaction" => {
+            let contact = match record
+                .fields
+                .get("contact")
+                .and_then(serde_json::Value::as_bool)
+            {
+                Some(true) => " · in contact",
+                Some(false) => " · no contact",
+                None => "",
+            };
+            format!("{} · {}{contact}", text("hand"), text("object"))
+        }
+        "state" => {
+            let (before, after) = (text("before"), text("after"));
+            let change = match (before.is_empty(), after.is_empty()) {
+                (false, false) => format!("{before} → {after}"),
+                (true, false) => after,
+                (false, true) => before,
+                (true, true) => String::new(),
+            };
+            let head = format!("{} · {}", text("object"), text("attribute"));
+            if change.is_empty() {
+                head
+            } else {
+                format!("{head}: {change}")
+            }
+        }
+        "flag" => format!("{}: {}", text("kind"), text("note")),
+        "progress" => {
+            let value = record
+                .fields
+                .get("value")
+                .and_then(serde_json::Value::as_f64)
+                .unwrap_or_default();
+            let done = record
+                .fields
+                .get("done")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or_default();
+            format!("{:.0}%{}", value * 100., if done { " · done" } else { "" })
+        }
+        _ => serde_json::to_string(&record.fields).unwrap_or_default(),
+    }
+}
+
+/// Reads published annotation records in time order. Local and read-only: it
+/// opens sidecars only, makes no model call, and returns records unchanged.
+pub fn timeline(
+    workspace: &Path,
+    path: Option<&Path>,
+    options: &TimelineOptions,
+) -> Result<Timeline> {
+    let wanted = options.kind.as_ref().map(|kind| {
+        let item = kind.strip_prefix("semantic.").unwrap_or(kind);
+        format!("semantic.{item}")
+    });
+    let selection = path
+        .map(|p| {
+            if p.exists() {
+                fs::canonicalize(p)
+            } else {
+                Ok(p.to_owned())
+            }
+        })
+        .transpose()?;
+    let mut episodes = Vec::new();
+    for entry in read_registry(workspace)? {
+        if selection
+            .as_ref()
+            .is_some_and(|path| !entry.media.starts_with(path) && !entry.sidecar.starts_with(path))
+        {
+            continue;
+        }
+        let episode: Episode =
+            serde_json::from_slice(&fs::read(entry.sidecar.join("episode.json"))?)
+                .context("invalid registered episode")?;
+        episode.validate()?;
+        let mut annotations = Vec::new();
+        let mut entries = Vec::new();
+        for stream in &episode.streams {
+            if !matches!(stream, crate::episode::Stream::Video { .. }) {
+                continue;
+            }
+            let directory = crate::index::stations::stream_directory(
+                &entry.sidecar,
+                stream.id(),
+                &episode.time.reference,
+            );
+            for name in file_names(&directory, ".jsonl")? {
+                if !name.starts_with("semantic.") || name.contains("conflicts") {
+                    continue;
+                }
+                let file = AnnotationFile::read(&directory.join(format!("{name}.jsonl")))?;
+                // A file whose inputs changed describes media that no longer
+                // exists in that form; showing its records would mislead.
+                if file.header.stream != stream.id()
+                    || !crate::index::stations::has_current_input(&episode, &file)?
+                {
+                    continue;
+                }
+                annotations.push(name.clone());
+                if wanted.as_ref().is_some_and(|kind| kind != &name) {
+                    continue;
+                }
+                for record in file.records {
+                    entries.push(TimelineEntry {
+                        episode: episode.episode_id.clone(),
+                        stream: stream.id().to_owned(),
+                        annotation: name.clone(),
+                        start_us: record.start_us,
+                        end_us: record.end_us,
+                        summary: summarize_record(&name, &record),
+                        record,
+                    });
+                }
+            }
+        }
+        if annotations.is_empty() {
+            continue;
+        }
+        annotations.sort();
+        annotations.dedup();
+        entries.sort_by(|a, b| {
+            (a.start_us, a.end_us, &a.annotation, &a.stream).cmp(&(
+                b.start_us,
+                b.end_us,
+                &b.annotation,
+                &b.stream,
+            ))
+        });
+        let total = entries.len();
+        entries.truncate(options.limit);
+        episodes.push(TimelineEpisode {
+            episode_id: entry.episode_id,
+            duration_us: episode.duration_us().ok(),
+            media: entry.media,
+            sidecar: entry.sidecar,
+            annotations,
+            total,
+            entries,
+        });
+    }
+    Ok(Timeline { episodes })
 }
 
 /// Reads only local state: no dependency probe, model call, lock, or filesystem mutation.
@@ -182,6 +411,7 @@ pub fn inspect(workspace: &Path, path: Option<&Path>) -> Result<Status> {
         episodes.push(EpisodeStatus {
             episode_id: entry.episode_id,
             media_present: entry.media.is_file(),
+            duration_us: episode.duration_us().ok(),
             media: entry.media,
             sidecar: entry.sidecar,
             annotations,

--- a/src/status.rs
+++ b/src/status.rs
@@ -254,6 +254,17 @@ pub fn timeline(
                 {
                     continue;
                 }
+                // The same validation the summary applies. A sidecar is
+                // authoritative, so a corrupt one is an error to report, not a
+                // set of records to hand back as if they had been published.
+                let coverage = episode
+                    .video_coverage(stream.id())?
+                    .context("annotation stream has no episode coverage")?;
+                file.validate_in_range(coverage, None)?;
+                anyhow::ensure!(
+                    file.header.episode == episode.episode_id,
+                    "annotation provenance does not match its episode"
+                );
                 annotations.push(name.clone());
                 if wanted.as_ref().is_some_and(|kind| kind != &name) {
                     continue;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -512,7 +512,7 @@ fn human_mode_renders_text_and_json_mode_stays_machine_readable() {
     let status = cli(dir.path(), &["status"]);
     assert!(status.status.success());
     let text = String::from_utf8_lossy(&status.stdout);
-    assert!(text.contains("Videos (0)"), "{text}");
+    assert!(text.contains("no videos yet"), "{text}");
     assert!(text.contains("key not set"), "{text}");
     assert!(text.contains("not checked"), "{text}");
 
@@ -528,8 +528,12 @@ fn human_mode_renders_text_and_json_mode_stays_machine_readable() {
     assert_eq!(set.status.code(), Some(2));
     assert!(set.stdout.is_empty());
     let text = String::from_utf8_lossy(&set.stderr);
-    assert!(text.starts_with("error:"), "{text}");
+    assert!(text.starts_with('\u{2717}'), "{text}");
     assert!(text.contains("GEMINI_API_KEY"), "{text}");
+    assert!(
+        text.contains("exit 2 \u{b7} invalid arguments or configuration"),
+        "{text}"
+    );
     let removed = cli(dir.path(), &["auth", "remove"]);
     assert!(removed.status.success());
     assert!(String::from_utf8_lossy(&removed.stdout).contains("No saved Gemini key"));
@@ -539,18 +543,18 @@ fn human_mode_renders_text_and_json_mode_stays_machine_readable() {
     assert_eq!(missing.status.code(), Some(2));
     assert!(missing.stdout.is_empty());
     let text = String::from_utf8_lossy(&missing.stderr);
-    assert!(text.starts_with("error:"), "{text}");
+    assert!(text.starts_with('\u{2717}'), "{text}");
     assert!(
         text.contains("no such file or directory: missing.mp4"),
         "{text}"
     );
-    assert!(text.contains("hint:"), "{text}");
+    assert!(text.contains("cerul status"), "{text}");
 
     // A refusal for a missing selection names a command that works.
     let empty = cli(dir.path(), &["remove"]);
     assert_eq!(empty.status.code(), Some(2));
     let text = String::from_utf8_lossy(&empty.stderr);
-    assert!(text.contains("hint: cerul remove ./video.mp4"), "{text}");
+    assert!(text.contains("cerul remove ./video.mp4"), "{text}");
 
     // Argument errors keep clap's own formatting and exit code.
     let bad = cli(dir.path(), &["search", "--limit", "many"]);
@@ -663,4 +667,100 @@ fn completions_are_printed_verbatim_and_removal_of_an_unindexed_video_is_a_no_op
         "{}",
         String::from_utf8_lossy(&missing.stderr)
     );
+}
+
+#[test]
+fn the_skill_installs_where_agents_look_and_never_replaces_a_hand_written_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let printed = cli(dir.path(), &["skill", "--print"]);
+    assert!(printed.status.success());
+    assert!(printed.stderr.is_empty());
+    let text = String::from_utf8(printed.stdout.clone()).unwrap();
+    assert!(text.starts_with("---\nname: cerul\n"), "{text}");
+    assert!(text.contains("generated-by: cerul"), "{text}");
+    // The reference is generated, so every command has to appear in it.
+    for command in [
+        "cerul index",
+        "cerul annotate",
+        "cerul search",
+        "cerul status",
+    ] {
+        assert!(
+            text.contains(&format!("### {command}")),
+            "{command} missing"
+        );
+    }
+    assert!(text.contains("--timeline"), "{text}");
+
+    let installed = cli(dir.path(), &["skill", "--install", "claude"]);
+    assert!(
+        installed.status.success(),
+        "{}",
+        String::from_utf8_lossy(&installed.stderr)
+    );
+    let path = dir.path().join(".claude/skills/cerul/SKILL.md");
+    assert_eq!(std::fs::read(&path).unwrap(), printed.stdout);
+    // Installing again replaces Cerul's own copy without asking.
+    assert!(
+        cli(dir.path(), &["skill", "--install", "claude"])
+            .status
+            .success()
+    );
+
+    let elsewhere = dir.path().join("skills");
+    assert!(
+        cli(
+            dir.path(),
+            &["skill", "--dir", elsewhere.to_str().unwrap(), "--dry-run"]
+        )
+        .status
+        .success()
+    );
+    assert!(!elsewhere.exists(), "a dry run writes nothing");
+
+    std::fs::write(&path, "---\nname: cerul\n---\nmine\n").unwrap();
+    let refused = cli(dir.path(), &["--json", "skill", "--install", "claude"]);
+    assert_eq!(refused.status.code(), Some(2));
+    assert_eq!(
+        final_json(&refused)["error"]["code"],
+        "invalid_configuration"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "---\nname: cerul\n---\nmine\n"
+    );
+}
+
+#[test]
+fn the_timeline_reads_local_files_only_and_rejects_a_type_that_does_not_exist() {
+    let dir = tempfile::tempdir().unwrap();
+    let empty = cli(dir.path(), &["--json", "status", "--timeline"]);
+    assert!(empty.status.success());
+    assert_eq!(final_json(&empty)["episodes"], serde_json::json!([]));
+    assert!(empty.stderr.is_empty());
+    // Reading sidecars must not bring a workspace into existence.
+    assert!(!dir.path().join(".cerul").exists());
+
+    let unknown = cli(
+        dir.path(),
+        &["--json", "status", "--timeline", "--type", "pose"],
+    );
+    assert_eq!(unknown.status.code(), Some(2));
+    let message = final_json(&unknown)["error"]["message"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    assert!(message.contains("pose"), "{message}");
+    assert!(message.contains("subtask"), "{message}");
+
+    // A local read and an endpoint probe are different requests.
+    let both = cli(
+        dir.path(),
+        &["--json", "status", "--timeline", "--providers"],
+    );
+    assert_eq!(both.status.code(), Some(2));
+    // --type and --limit belong to the timeline, not to the summary.
+    let stray = cli(dir.path(), &["--json", "status", "--type", "event"]);
+    assert_eq!(stray.status.code(), Some(2));
+    assert_eq!(final_json(&stray)["error"]["code"], "invalid_arguments");
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -737,6 +737,14 @@ fn the_skill_installs_where_agents_look_and_never_replaces_a_hand_written_file()
     std::fs::write(&path, &edited).unwrap();
     let kept = cli(dir.path(), &["skill", "--install", "claude"]);
     assert_eq!(kept.status.code(), Some(2));
+    // An edit to a file an older build wrote has to be protected too: an
+    // upgrade is exactly when that file is about to be replaced.
+    let older = edited.replace("generated-by: cerul 0.", "generated-by: cerul 0.0.1-0.");
+    std::fs::write(&path, &older).unwrap();
+    let upgrade = cli(dir.path(), &["skill", "--install", "claude"]);
+    assert_eq!(upgrade.status.code(), Some(2));
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), older);
+    std::fs::write(&path, &edited).unwrap();
     assert!(
         String::from_utf8_lossy(&kept.stderr).contains("changed after cerul wrote it"),
         "{}",
@@ -786,6 +794,20 @@ fn printing_and_redirecting_the_skill_need_no_home_directory() {
             .as_str()
             .unwrap()
             .contains("--dir")
+    );
+    // Two destinations cannot both be honoured, so they cannot both be given.
+    let both = homeless(&[
+        "skill",
+        "--install",
+        "codex",
+        "--dir",
+        elsewhere.to_str().unwrap(),
+    ]);
+    assert_eq!(both.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&both.stderr).contains("cannot be used with"),
+        "{}",
+        String::from_utf8_lossy(&both.stderr)
     );
 }
 
@@ -859,7 +881,9 @@ fn a_partial_annotation_carries_the_command_that_continues_it() {
         .iter()
         .map(|argument| argument.as_str().unwrap().to_owned())
         .collect();
-    assert_eq!(argv[0], "cerul");
+    // The program is repeated as it was invoked: a path was used because the
+    // binary is not on PATH, and shortening it would break the copied command.
+    assert_eq!(argv[0], env!("CARGO_BIN_EXE_cerul"));
     assert_eq!(value["retry"]["reason"], "incomplete");
     // Every choice survives, or running it again would not be the same run.
     for argument in [

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -729,6 +729,64 @@ fn the_skill_installs_where_agents_look_and_never_replaces_a_hand_written_file()
         std::fs::read_to_string(&path).unwrap(),
         "---\nname: cerul\n---\nmine\n"
     );
+
+    // Editing an installed skill and reinstalling must not lose the edit, even
+    // though the file still carries the line that says cerul wrote it.
+    let mut edited = String::from_utf8(printed.stdout.clone()).unwrap();
+    edited.push_str("\nMy own note.\n");
+    std::fs::write(&path, &edited).unwrap();
+    let kept = cli(dir.path(), &["skill", "--install", "claude"]);
+    assert_eq!(kept.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&kept.stderr).contains("changed after cerul wrote it"),
+        "{}",
+        String::from_utf8_lossy(&kept.stderr)
+    );
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), edited);
+    let forced = cli(dir.path(), &["skill", "--install", "claude", "--force"]);
+    assert!(forced.status.success());
+    assert_eq!(std::fs::read(&path).unwrap(), printed.stdout);
+}
+
+#[test]
+fn printing_and_redirecting_the_skill_need_no_home_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let homeless = |args: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_cerul"))
+            .current_dir(dir.path())
+            .env_clear()
+            .env("PATH", std::env::var_os("PATH").unwrap())
+            .args(args)
+            .output()
+            .unwrap()
+    };
+    let printed = homeless(&["skill", "--print"]);
+    assert!(
+        printed.status.success(),
+        "{}",
+        String::from_utf8_lossy(&printed.stderr)
+    );
+    assert!(String::from_utf8_lossy(&printed.stdout).starts_with("---\nname: cerul\n"));
+    let elsewhere = dir.path().join("skills");
+    let written = homeless(&["skill", "--dir", elsewhere.to_str().unwrap()]);
+    assert!(
+        written.status.success(),
+        "{}",
+        String::from_utf8_lossy(&written.stderr)
+    );
+    assert_eq!(
+        std::fs::read(elsewhere.join("cerul/SKILL.md")).unwrap(),
+        printed.stdout
+    );
+    // Only an agent's own directory needs to know where home is.
+    let agent = homeless(&["--json", "skill", "--install", "claude"]);
+    assert_eq!(agent.status.code(), Some(2));
+    assert!(
+        final_json(&agent)["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("--dir")
+    );
 }
 
 #[test]
@@ -763,4 +821,59 @@ fn the_timeline_reads_local_files_only_and_rejects_a_type_that_does_not_exist() 
     let stray = cli(dir.path(), &["--json", "status", "--type", "event"]);
     assert_eq!(stray.status.code(), Some(2));
     assert_eq!(final_json(&stray)["error"]["code"], "invalid_arguments");
+}
+
+#[test]
+fn a_partial_annotation_carries_the_command_that_continues_it() {
+    let dir = tempfile::tempdir().unwrap();
+    video(dir.path());
+    let media = dir.path().join("sample.mp4");
+    // Port 9 discards connections, so the vision endpoint fails after the local
+    // work succeeds: the run is partial, which is what carries a retry.
+    let output = Command::new(env!("CARGO_BIN_EXE_cerul"))
+        .current_dir(dir.path())
+        .env_clear()
+        .env("PATH", std::env::var_os("PATH").unwrap())
+        .env("HOME", dir.path())
+        .env("GEMINI_API_KEY", "test-key")
+        .args([
+            "--json",
+            "annotate",
+            media.to_str().unwrap(),
+            "--semantic",
+            "subtask",
+            "--jobs",
+            "1",
+            "--set",
+            "vision.base_url=\"http://127.0.0.1:9\"",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(6));
+    let value = final_json(&output);
+    assert_eq!(value["partial"], true);
+    // The result describes its own recovery, in the schema, not beside it.
+    let argv: Vec<String> = value["retry"]["argv"]
+        .as_array()
+        .expect("a partial run offers a retry")
+        .iter()
+        .map(|argument| argument.as_str().unwrap().to_owned())
+        .collect();
+    assert_eq!(argv[0], "cerul");
+    assert_eq!(value["retry"]["reason"], "incomplete");
+    // Every choice survives, or running it again would not be the same run.
+    for argument in [
+        media.to_str().unwrap(),
+        "--semantic",
+        "subtask",
+        "vision.base_url=\"http://127.0.0.1:9\"",
+    ] {
+        assert!(argv.iter().any(|value| value == argument), "{argv:?}");
+    }
+    assert!(!argv.iter().any(|value| value == "--recompute"), "{argv:?}");
+    // A source that is only a file name cannot say which input it came from,
+    // and two directories can hold the same name.
+    let source = value["modules"][0]["source"].as_str().unwrap();
+    assert!(source.ends_with("/sample.mp4"), "{source}");
+    assert!(std::path::Path::new(source).is_absolute(), "{source}");
 }


### PR DESCRIPTION
Running `cerul annotate` printed a clap usage error, an annotation run ended without saying where its files went, and nothing told an agent how to operate the command line. This reworks the human output around one grammar, adds a read-only way to look at what a run produced, completes an under-specified command at a terminal, and ships the agent contract as a skill the binary writes itself.

It implements the design recorded in [design/cli-interaction](design/cli-interaction/README.md).

## Output grammar

Every screen is a title, aligned facts, a live area on stderr, a receipt of real paths on stdout, and at most three next commands.

- The annotation receipt names each published file and its record count, then points at the timeline and a filter search.
- A partial run separates what was published from what stopped, and prints the command that continues it.
- Errors state what failed, how to recover, and the exit code with its category.
- Search results lose the box frame and emoji, keep global numbering that matches `cerul open N`, and read `similarity 82%`: a ranking score is not a probability. The number and the ranking are unchanged.
- Status becomes one row per video with a column per capability, so "indexed" stops standing for three different facts. Naming a path adds the sidecar locations.

## Reading results back

`cerul status PATH --timeline` prints published annotation records in time order, with `--type` and `--limit`. It reads sidecars only: no model call, no network, no lock.

```
demo.mp4  02:30  ·  subtask event interaction state  ·  ./demo.mp4.cerul/

  00:00 – 00:14   subtask       reach for the cup
  00:03           event         grasp cup
  00:20           state         cup · location: on table → in hand
```

## Guidance

At a terminal, a bare `annotate`, `index`, or `search` asks for what is missing and then runs the exact command it prints, so the second run can be typed instead of answered. A LeRobot dataset is asked about with its own episode indices and camera feature keys, never assumed ones.

Guidance never appears with `--json`, `--yes`, `-q`, `--dry-run`, or without a terminal at both ends; those paths are byte-for-byte unchanged. Running `cerul` still prints the read-only home it always printed and offers the menu underneath it.

Two deviations from the design draft, both deliberate:

- **No new dependency.** The prompts are built on `console`, which the progress bars already use. `dialoguer` would have put a second copy of `console` in the binary for a menu and a text input.
- **No `outputs` array in the JSON.** `modules[]` already is that list now that each entry carries its own `path`; two copies of one fact in one object is a defect waiting to happen.

## Agent mode

`--json` is the whole contract, documented in [docs/agent.md](docs/agent.md).

- Events gain `published` (a validated file, with its record count and path) and `checkpoint` (work a rerun will reuse). A checkpoint is not a published file, and the two are now distinguishable.
- A partial annotate result carries `retry.argv`: the original invocation with only the failure's fix applied, runnable verbatim. `--recompute` is never added to it.
- Modules carry the path they published and the source they belong to, so episodes of one LeRobot dataset stop being labelled by the MP4 shard they share.
- `cerul skill --install claude|codex|pi` writes an Agent Skills file whose command reference is generated from this build's own argument definitions. A test keeps the committed copy at `skills/cerul/SKILL.md` equal to it, and installing never replaces a file somebody wrote by hand.

No HTTP or MCP serving; subprocess JSON stays the integration path.

## Verification

- 112 tests pass, including new coverage of the receipt, the partial block, the timeline, shell quoting, the retry command, the skill install and its overwrite refusal, and `--timeline` argument validation.
- `cargo fmt --check`, strict clippy, generated schemas with no diff, `scripts/check-docs.py` over 37 files and 182 command examples, and the source-package content check.
- A pseudo-terminal walk through each guided flow, including a two-camera LeRobot v3.1 dataset, which produced `cerul annotate ./egodemo --semantic --only 000000` from real metadata.
- A rate-limited endpoint driving a real partial result, whose retry command repeated every original argument, including a quoted `--set`, and appended `--rpm 6`.

Annotation algorithms, model requests, dataset formats, exit codes, and dependency versions are unchanged. No release is published, so an installed binary keeps its current behaviour until one is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)