### PR TITLE
chore: prepare v0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cerul"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerul"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 license = "Apache-2.0"
 description = "Searchable video and annotation data, using your own model endpoints"

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -9,6 +9,15 @@ Existing tags and `ffmpeg-vendor-*` assets must be preserved for downstream comp
 Public installation uses GitHub Releases and the permanent website installer
 redirect. npm and Homebrew publication are separate from generating their artifacts.
 
+0. In the release PR, set the version in Cargo.toml and packaging/dist.toml,
+   refresh Cargo.lock, and regenerate the agent skill, which records the version
+   and a digest of its own contents:
+
+   ```sh
+   cargo run --locked -- skill --print > skills/cerul/SKILL.md
+   ```
+
+   A stale copy fails `cargo test` rather than reaching a release.
 1. Verify PR checks and acceptance results, then merge the release PR into `main`.
 2. From the merged `main`, confirm Cargo.toml and packaging/dist.toml agree on
    the version being released, then create and push the matching tag. The

--- a/packaging/dist.toml
+++ b/packaging/dist.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerul"
-version = "0.0.6"
+version = "0.0.7"
 description = "Searchable video and annotation data, using your own model endpoints"
 license = "Apache-2.0 AND GPL-2.0-or-later AND Zlib"
 homepage = "https://cerul.ai"

--- a/skills/cerul/SKILL.md
+++ b/skills/cerul/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cerul
 description: Search local videos by meaning, exact words, or a reference image, and annotate actions, events, interactions, and states in videos or LeRobot demonstrations. Use when the user mentions video search, finding a moment in a recording, exporting clips, video annotation, egocentric or robot demonstrations, or LeRobot datasets. Requires the cerul command-line tool.
-generated-by: cerul 0.0.6
+generated-by: cerul 0.0.7
 generated-sha256: e0f5e6313d19393cf8e283f595734d14c3ac64ff5fea743383ccd1367b9f1a81
 ---
 


### PR DESCRIPTION
Sets the version for the release that carries the CLI redesign and agent mode from #257.

- Cargo.toml, Cargo.lock, and packaging/dist.toml agree on 0.0.7.
- `skills/cerul/SKILL.md` is regenerated: it records the version that wrote it and a digest of its own contents, so it changes with every version bump.
- The release checklist gains that regeneration as an explicit step. A stale copy already fails `cargo test`, but the runbook should say so rather than leave it to be discovered.

No behaviour changes. Verified locally: 116 tests, `cargo fmt --check`, strict clippy, generated schemas with no diff, and the documentation and source-package checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)