### PR TITLE
Add cerul upgrade, and say anywhere how to get a newer build

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Supports **macOS Apple Silicon** and **Linux x86_64 (Ubuntu 24.04 or newer)**.
 curl -fsSL https://cerul.ai/install.sh | sh
 ```
 
+Later, `cerul upgrade` installs the newest release over this one and leaves your
+workspace, key, and annotations alone.
+
 ### 2. Add a video
 
 ```sh

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,6 +44,8 @@ Cerul 是一个搜索视频、导出片段的命令行工具。安装包已包�
 curl -fsSL https://cerul.ai/install.sh | sh
 ```
 
+之后用 `cerul upgrade` 升级到最新版本，工作区、密钥和标注文件都不受影响。
+
 ### 2. 添加视频
 
 ```sh

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -44,6 +44,8 @@ Cerul 是一個搜尋影片、匯出片段的命令列工具。安裝包已包�
 curl -fsSL https://cerul.ai/install.sh | sh
 ```
 
+之後用 `cerul upgrade` 升級到最新版本，工作區、金鑰和標註檔案都不受影響。
+
 ### 2. 加入影片
 
 ```sh

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -80,14 +80,18 @@ The schema for these lives in [`schemas/event.json`](../schemas/event.json).
 
 `index`, `search`, `status`, `status --timeline`, `annotate`, and `remove`
 each have a generated schema in [`schemas/`](../schemas/), produced from the Rust
-result types. `auth`, `open`, and `skill` return small objects with no generated
-schema; their shapes are:
+result types. `auth`, `open`, `skill`, and `upgrade` return small objects with no
+generated schema; their shapes are:
 
 ```json
 {"provider":"gemini","endpoint":"…","env":"GEMINI_API_KEY","env_set":false,"saved":true,"credentials_path":"…","action":"set"}
 {"media":"/v/demo.mp4","start_us":12000000,"player":"mpv","seeks":true,"opened":true}
-{"version":"0.0.6","installed":"…/SKILL.md","targets":{"claude":"…"},"skill":"---\nname: cerul\n…"}
+{"version":"0.0.7","installed":"…/SKILL.md","targets":{"claude":"…"},"skill":"---\nname: cerul\n…"}
+{"current":"0.0.6","latest":"0.0.7","newer":true,"installer":"https://…/cerul-installer.sh","upgraded":false}
 ```
+
+`upgrade` reports in `--json` and installs nothing; replacing the program needs
+an explicit `--yes`, which is a decision to put to the user rather than take.
 
 `auth` never reports a key's value, or any part of one. Two fields on the
 generated results matter most to an agent.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,6 +25,24 @@ when prompted. Model processing sends inputs to Gemini and may incur API charges
 You can also download an archive from [GitHub Releases](https://github.com/cerul-ai/cerul/releases/latest).
 Keep `cerul`, `cerul-ffmpeg`, and `cerul-ffprobe` together when moving them.
 
+## Upgrade
+
+```sh
+cerul upgrade
+```
+
+It asks GitHub what the newest release is, tells you what it found, and installs
+it after you agree. What it runs is the installer that release published, so the
+version it names is the version you get. `--yes` skips the question, `--dry-run`
+only reports, and `--json` reports without installing anything.
+
+The upgrade replaces `cerul`, `cerul-ffmpeg`, and `cerul-ffprobe` where they are
+already installed. Your workspace, saved key, sidecar files, and indexes are
+untouched: they are read by the new version exactly as the old one left them.
+
+Re-running the install command above does the same thing, and is the way to
+upgrade a build that predates `cerul upgrade`.
+
 ## Run your first video
 
 The first interactive `index` or semantic `search`/`annotate` using the default

--- a/prompts/skill.md
+++ b/prompts/skill.md
@@ -17,6 +17,12 @@ https://github.com/cerul-ai/cerul/blob/main/docs/agent-setup.md. Do not install
 Rust, Python, Ollama, or system FFmpeg for this workflow, and do not switch to a
 source build when a download fails; report the error instead.
 
+`cerul --json upgrade` reports the newest published release and installs
+nothing. It replaces the program only with `--yes`, so ask the user before
+running `cerul upgrade --yes`: it changes which build answers every later
+command. A build too old for a flag you need is a reason to offer the upgrade,
+not to work around it.
+
 Run `cerul --json auth` to see whether a key is available. It reports whether a
 key is saved or exported, never the value. Never echo a key, print part of it,
 write it to a log or a commit, or read an unrelated project's `.env`. When no key

--- a/skills/cerul/SKILL.md
+++ b/skills/cerul/SKILL.md
@@ -2,7 +2,7 @@
 name: cerul
 description: Search local videos by meaning, exact words, or a reference image, and annotate actions, events, interactions, and states in videos or LeRobot demonstrations. Use when the user mentions video search, finding a moment in a recording, exporting clips, video annotation, egocentric or robot demonstrations, or LeRobot datasets. Requires the cerul command-line tool.
 generated-by: cerul 0.0.7
-generated-sha256: e0f5e6313d19393cf8e283f595734d14c3ac64ff5fea743383ccd1367b9f1a81
+generated-sha256: 5e32acf08e156e8e4969f4fd3dc79bab70bf0b95dc90d3bb4aaf620786ded8d8
 ---
 
 # Cerul
@@ -18,6 +18,12 @@ Run `cerul --version`. If it is missing, follow the installation runbook at
 https://github.com/cerul-ai/cerul/blob/main/docs/agent-setup.md. Do not install
 Rust, Python, Ollama, or system FFmpeg for this workflow, and do not switch to a
 source build when a download fails; report the error instead.
+
+`cerul --json upgrade` reports the newest published release and installs
+nothing. It replaces the program only with `--yes`, so ask the user before
+running `cerul upgrade --yes`: it changes which build answers every later
+command. A build too old for a flag you need is a reason to offer the upgrade,
+not to work around it.
 
 Run `cerul --json auth` to see whether a key is available. It reports whether a
 key is saved or exported, never the value. Never echo a key, print part of it,
@@ -213,6 +219,11 @@ Remove indexed videos, or free the disk they and their caches use
   --all-indexes               Free every search index; each rebuilds from sidecars with no model calls
   --index <SPACE>             Free one search index by space id; rebuilt from sidecars on next use
   --compact                   Reclaim space inside search indexes without dropping them
+
+### cerul upgrade
+
+Install the newest published release of Cerul over this one
+
 
 ### cerul skill
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod credentials;
 mod documentation_tests;
 mod guide;
 mod render;
+mod upgrade;
 use anyhow::{Context, Result};
 use cerul::{
     config::Config,
@@ -145,6 +146,8 @@ enum Command {
     Annotate(AnnotateArgs),
     /// Remove indexed videos, or free the disk they and their caches use.
     Remove(RemoveArgs),
+    /// Install the newest published release of Cerul over this one.
+    Upgrade,
     /// Print or install the agent skill that teaches this CLI to a coding agent.
     Skill(SkillArgs),
     /// Print a shell completion script, for example: cerul completions zsh.
@@ -613,6 +616,42 @@ fn skill(cli: &Cli, args: &SkillArgs) -> Result<(Outcome, u8)> {
     ))
 }
 
+/// Replacing the program is the one operation that changes what runs next time,
+/// so it says what it found, then what it will do, and only then asks. A machine
+/// reading this gets the report and installs nothing without `--yes`.
+async fn upgrade(cli: &Cli, sink: &Sink) -> Result<(Outcome, u8)> {
+    let available = upgrade::check().await.map_err(|e| category(4, e))?;
+    if !available.newer || cli.dry_run {
+        return Ok((Outcome::Upgrade(available, false), 0));
+    }
+    let human = sink.mode == Mode::Human && !cli.quiet;
+    let go = if cli.yes {
+        true
+    } else if human {
+        let palette = Palette::new(console::colors_enabled_stderr());
+        let _ = render::upgrade_plan(&mut io::stderr(), &palette, &available);
+        confirm(
+            "upgrading",
+            &format!(
+                "Replace cerul {} with {}?",
+                available.current, available.latest
+            ),
+        )
+        .map_err(|e| category(2, e))?
+    } else {
+        // Reporting is safe for anyone; replacing the program is not something
+        // to do because nobody was there to say no.
+        false
+    };
+    if !go {
+        return Ok((Outcome::Upgrade(available, false), 0));
+    }
+    upgrade::install(&available)
+        .await
+        .map_err(|e| category(4, e))?;
+    Ok((Outcome::Upgrade(available, true), 0))
+}
+
 /// Provider wording differs by endpoint, so the categories are matched on the
 /// signals every one of them sends rather than on one vendor's message.
 fn rate_limited(error: &str) -> bool {
@@ -693,6 +732,8 @@ enum Outcome {
     },
     Timeline(cerul::status::Timeline, Option<String>),
     Skill(SkillReport),
+    /// What the newest release is, and whether this run installed it.
+    Upgrade(upgrade::Available, bool),
     Auth(render::KeyState, Option<&'static str>),
     Remove(
         cerul::clean::Report,
@@ -737,6 +778,11 @@ impl Outcome {
             Outcome::Remove(report, _, _) => serde_json::to_value(report)?,
             Outcome::Timeline(timeline, _) => serde_json::to_value(timeline)?,
             Outcome::Skill(report) => serde_json::to_value(report)?,
+            Outcome::Upgrade(available, upgraded) => {
+                let mut value = serde_json::to_value(available)?;
+                value["upgraded"] = json!(upgraded);
+                value
+            }
             Outcome::Annotate(report, _) => serde_json::to_value(report)?,
         })
     }
@@ -751,6 +797,9 @@ impl Outcome {
             } => render::status(out, palette, status, models, *probed, *detail),
             Outcome::Timeline(timeline, kind) => {
                 render::timeline(out, palette, timeline, kind.as_deref())
+            }
+            Outcome::Upgrade(available, upgraded) => {
+                render::upgrade(out, palette, available, *upgraded)
             }
             Outcome::Skill(report) => match &report.skill {
                 // The printed skill is the file itself: no colour, no heading,
@@ -1030,10 +1079,13 @@ async fn execute(
     sink: &Sink,
     cancel: CancellationToken,
 ) -> Result<(Outcome, u8)> {
-    // Writing the skill touches no workspace, so it is answered before one has
-    // to exist.
+    // Writing the skill and replacing the program touch no workspace, so they are
+    // answered before one has to exist.
     if let Some(Command::Skill(args)) = &cli.command {
         return skill(cli, args);
+    }
+    if let Some(Command::Upgrade) = &cli.command {
+        return upgrade(cli, sink).await;
     }
     let workspace = cli
         .workspace
@@ -1328,8 +1380,8 @@ async fn execute(
                 0,
             ))
         }
-        Some(Command::Skill(_)) => {
-            unreachable!("the skill is written before a workspace is resolved")
+        Some(Command::Skill(_)) | Some(Command::Upgrade) => {
+            unreachable!("these are answered before a workspace is resolved")
         }
         Some(Command::Completions { .. }) => {
             unreachable!("completions are printed before the runtime starts")

--- a/src/main.rs
+++ b/src/main.rs
@@ -619,8 +619,8 @@ fn skill(cli: &Cli, args: &SkillArgs) -> Result<(Outcome, u8)> {
 /// Replacing the program is the one operation that changes what runs next time,
 /// so it says what it found, then what it will do, and only then asks. A machine
 /// reading this gets the report and installs nothing without `--yes`.
-async fn upgrade(cli: &Cli, sink: &Sink) -> Result<(Outcome, u8)> {
-    let available = upgrade::check().await.map_err(|e| category(4, e))?;
+async fn upgrade(cli: &Cli, sink: &Sink, cancel: CancellationToken) -> Result<(Outcome, u8)> {
+    let available = upgrade::check(&cancel).await.map_err(|e| category(4, e))?;
     if !available.newer || cli.dry_run {
         return Ok((Outcome::Upgrade(available, false), 0));
     }
@@ -646,9 +646,12 @@ async fn upgrade(cli: &Cli, sink: &Sink) -> Result<(Outcome, u8)> {
     if !go {
         return Ok((Outcome::Upgrade(available, false), 0));
     }
-    upgrade::install(&available)
-        .await
-        .map_err(|e| category(4, e))?;
+    // The installer's own output is captured, so a person watching gets this
+    // instead of nothing while a hundred megabytes come down.
+    sink.spinner(&format!("Installing cerul {}…", available.latest));
+    let installed = upgrade::install(&available, &cancel).await;
+    sink.finish();
+    installed.map_err(|e| category(4, e))?;
     Ok((Outcome::Upgrade(available, true), 0))
 }
 
@@ -1085,7 +1088,7 @@ async fn execute(
         return skill(cli, args);
     }
     if let Some(Command::Upgrade) = &cli.command {
-        return upgrade(cli, sink).await;
+        return upgrade(cli, sink, cancel).await;
     }
     let workspace = cli
         .workspace

--- a/src/render.rs
+++ b/src/render.rs
@@ -1029,6 +1029,93 @@ pub fn status(
     Ok(())
 }
 
+/// What replacing the program will do, before anybody is asked to agree to it.
+pub fn upgrade_plan(
+    out: &mut dyn Write,
+    palette: &Palette,
+    available: &crate::upgrade::Available,
+) -> io::Result<()> {
+    writeln!(
+        out,
+        "{} {}",
+        palette.bold(&format!(
+            "cerul {} → {}",
+            available.current, available.latest
+        )),
+        palette.dim("· the newest published release")
+    )?;
+    writeln!(out)?;
+    facts(
+        out,
+        palette,
+        &[
+            ("Runs", available.installer.clone()),
+            ("Replaces", crate::upgrade::INSTALLED.join(", ")),
+            (
+                "Keeps",
+                "your workspace, saved key, and annotation files".into(),
+            ),
+        ],
+    )?;
+    writeln!(out)
+}
+
+/// The upgrade result: what is installed now, and what to do about it.
+pub fn upgrade(
+    out: &mut dyn Write,
+    palette: &Palette,
+    available: &crate::upgrade::Available,
+    upgraded: bool,
+) -> io::Result<()> {
+    if upgraded {
+        writeln!(
+            out,
+            "{} {}",
+            palette.ok("✓"),
+            palette.bold(&format!("Upgraded to cerul {}", available.latest))
+        )?;
+        return next_block(
+            out,
+            palette,
+            &[
+                ("cerul --version", "confirm which build answers now"),
+                ("cerul", "what is indexed and what to do next"),
+            ],
+        );
+    }
+    if !available.newer {
+        return writeln!(
+            out,
+            "{} {}   {}",
+            palette.ok("✓"),
+            palette.bold(&format!(
+                "cerul {} is the newest release",
+                available.current
+            )),
+            palette.dim("nothing to install")
+        );
+    }
+    writeln!(
+        out,
+        "{} {}",
+        palette.warn("!"),
+        palette.bold(&format!(
+            "cerul {} is behind {}",
+            available.current, available.latest
+        ))
+    )?;
+    writeln!(out)?;
+    facts(out, palette, &[("Installer", available.installer.clone())])?;
+    next_block(
+        out,
+        palette,
+        &[(
+            "cerul upgrade --yes",
+            "install it without being asked again",
+        )],
+    )
+}
+
 /// Where the agent skill can go, or where it just went. Read-only until asked.
 pub fn skill(
     out: &mut dyn Write,
@@ -2449,6 +2536,48 @@ mod tests {
             "{text}"
         );
         assert!(!text.contains("file-000.mp4"), "{text}");
+    }
+
+    #[test]
+    fn upgrading_says_what_it_would_replace_and_what_it_would_keep() {
+        let available = crate::upgrade::Available {
+            current: "0.0.6".into(),
+            latest: "0.0.7".into(),
+            newer: true,
+            installer: "https://example.test/v0.0.7/cerul-installer.sh".into(),
+        };
+        let render = |available: &crate::upgrade::Available, upgraded| {
+            let mut out = Vec::new();
+            super::upgrade(&mut out, &Palette::new(false), available, upgraded).unwrap();
+            String::from_utf8(out).unwrap()
+        };
+        // Behind, and not installed: the command to install is the whole point.
+        let text = render(&available, false);
+        assert!(text.contains("0.0.6 is behind 0.0.7"), "{text}");
+        assert!(text.contains("cerul upgrade --yes"), "{text}");
+        assert!(text.contains("cerul-installer.sh"), "{text}");
+
+        let text = render(&available, true);
+        assert!(text.contains("Upgraded to cerul 0.0.7"), "{text}");
+        assert!(text.contains("cerul --version"), "{text}");
+
+        // Nothing to do is a result, not a warning.
+        let current = crate::upgrade::Available {
+            current: "0.0.7".into(),
+            newer: false,
+            ..available.clone()
+        };
+        let text = render(&current, false);
+        assert!(text.contains("0.0.7 is the newest release"), "{text}");
+        assert!(!text.contains("upgrade --yes"), "{text}");
+
+        // What replacing the program touches, said before anyone agrees to it.
+        let mut out = Vec::new();
+        super::upgrade_plan(&mut out, &Palette::new(false), &available).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("cerul 0.0.6 → 0.0.7"), "{text}");
+        assert!(text.contains("cerul-ffmpeg"), "{text}");
+        assert!(text.contains("saved key"), "{text}");
     }
 
     #[test]

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,0 +1,161 @@
+//! Finding and installing the newest published release.
+//!
+//! Nothing here runs on its own: the command asks GitHub what the newest
+//! release is, says what it found, and installs only when a person or an
+//! explicit `--yes` says so. The script it runs is the one that release
+//! published, so what gets installed is the version that was reported.
+use anyhow::{Context, Result, ensure};
+use serde::Deserialize;
+use std::io::Write;
+
+/// Where releases are published. Named as a constant so the command can print
+/// exactly where it will look before it looks.
+const LATEST: &str = "https://api.github.com/repos/cerul-ai/cerul/releases/latest";
+/// The installer each release publishes, and the one the documented install
+/// command fetches.
+const INSTALLER: &str = "cerul-installer.sh";
+/// Executables the bundle installs together. Keeping them together is what
+/// makes the media tools match the CLI that calls them.
+pub const INSTALLED: [&str; 3] = ["cerul", "cerul-ffmpeg", "cerul-ffprobe"];
+
+#[derive(Deserialize)]
+struct Release {
+    tag_name: String,
+    assets: Vec<Asset>,
+}
+#[derive(Deserialize)]
+struct Asset {
+    name: String,
+    browser_download_url: String,
+}
+
+/// What the newest release is, and how this build compares to it.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Available {
+    pub current: String,
+    pub latest: String,
+    /// True when the published release is newer than the running build.
+    pub newer: bool,
+    /// The exact script that would run, from the release being installed.
+    pub installer: String,
+}
+
+/// Released versions compared number by number, so 0.0.10 is newer than 0.0.9
+/// where a string comparison would say the opposite. A suffix is ignored rather
+/// than guessed at; releases carry none.
+fn ordinal(value: &str) -> Vec<u64> {
+    value
+        .trim()
+        .trim_start_matches('v')
+        .split('.')
+        .map(|part| {
+            part.chars()
+                .take_while(|character| character.is_ascii_digit())
+                .collect::<String>()
+                .parse()
+                .unwrap_or(0)
+        })
+        .collect()
+}
+
+fn client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .user_agent(concat!("cerul/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .context("could not start an HTTPS client")
+}
+
+/// Asks what the newest release is. Reads only; installs nothing.
+pub async fn check() -> Result<Available> {
+    let response = client()?
+        .get(LATEST)
+        .send()
+        .await
+        .context("could not reach GitHub Releases")?;
+    ensure!(
+        response.status().is_success(),
+        "GitHub Releases answered HTTP {}",
+        response.status().as_u16()
+    );
+    let release: Release = response
+        .json()
+        .await
+        .context("GitHub Releases returned something this version cannot read")?;
+    let latest = release.tag_name.trim_start_matches('v').to_owned();
+    let installer = release
+        .assets
+        .into_iter()
+        .find(|asset| asset.name == INSTALLER)
+        .map(|asset| asset.browser_download_url)
+        .with_context(|| format!("release {latest} publishes no {INSTALLER}"))?;
+    let current = env!("CARGO_PKG_VERSION").to_owned();
+    Ok(Available {
+        newer: ordinal(&latest) > ordinal(&current),
+        current,
+        latest,
+        installer,
+    })
+}
+
+/// Runs the installer that release published. It writes the whole bundle to the
+/// same place the documented install command does, so an upgrade and a fresh
+/// install leave the machine in the same state.
+pub async fn install(available: &Available) -> Result<()> {
+    let response = client()?
+        .get(&available.installer)
+        .send()
+        .await
+        .context("could not download the installer")?;
+    ensure!(
+        response.status().is_success(),
+        "downloading the installer answered HTTP {}",
+        response.status().as_u16()
+    );
+    let script = response
+        .text()
+        .await
+        .context("the installer did not read")?;
+    // A redirect that lands on an error page is a page, not a script. Running it
+    // would be running whatever the page happens to contain.
+    ensure!(
+        script.starts_with("#!"),
+        "what was downloaded is not a shell script; install manually from {}",
+        available.installer
+    );
+    let mut file = tempfile::Builder::new()
+        .prefix("cerul-installer-")
+        .suffix(".sh")
+        .tempfile()
+        .context("could not write the installer to a temporary file")?;
+    file.write_all(script.as_bytes())?;
+    file.flush()?;
+    let status = std::process::Command::new("sh")
+        .arg(file.path())
+        .status()
+        .context("could not run the installer")?;
+    ensure!(
+        status.success(),
+        "the installer stopped with {}",
+        status
+            .code()
+            .map(|code| format!("exit {code}"))
+            .unwrap_or_else(|| "a signal".into())
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ordinal;
+
+    #[test]
+    fn versions_compare_by_number_rather_than_by_text() {
+        assert!(ordinal("0.0.10") > ordinal("0.0.9"));
+        assert!(ordinal("v0.1.0") > ordinal("0.0.99"));
+        assert!(ordinal("0.0.7") > ordinal("0.0.4"));
+        assert_eq!(ordinal("0.0.7"), ordinal("v0.0.7"));
+        // Nothing published carries a suffix, so it is ignored rather than
+        // ranked by a rule nobody agreed on.
+        assert_eq!(ordinal("0.0.7-rc1"), ordinal("0.0.7"));
+    }
+}

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -5,8 +5,10 @@
 //! explicit `--yes` says so. The script it runs is the one that release
 //! published, so what gets installed is the version that was reported.
 use anyhow::{Context, Result, ensure};
+use cerul::providers::{Failure, ProviderError};
 use serde::Deserialize;
-use std::io::Write;
+use std::{io::Write, path::PathBuf};
+use tokio_util::sync::CancellationToken;
 
 /// Where releases are published. Named as a constant so the command can print
 /// exactly where it will look before it looks.
@@ -17,6 +19,31 @@ const INSTALLER: &str = "cerul-installer.sh";
 /// Executables the bundle installs together. Keeping them together is what
 /// makes the media tools match the CLI that calls them.
 pub const INSTALLED: [&str; 3] = ["cerul", "cerul-ffmpeg", "cerul-ffprobe"];
+/// Tells the installer to write the bundle straight into one directory and to
+/// leave shell profiles alone: the directory a running Cerul came from is
+/// already on PATH, and it is the one that has to be replaced.
+const INSTALL_DIR: &str = "CERUL_UNMANAGED_INSTALL";
+
+fn cancelled() -> anyhow::Error {
+    ProviderError {
+        kind: Failure::Cancelled,
+        message: "operation cancelled".into(),
+    }
+    .into()
+}
+
+/// Awaits a request, or gives up the moment the run is cancelled. Without this
+/// a Ctrl+C during a download is only noticed once the download finishes.
+async fn interruptible<T>(
+    cancel: &CancellationToken,
+    work: impl std::future::Future<Output = reqwest::Result<T>>,
+) -> Result<T> {
+    tokio::select! {
+        biased;
+        () = cancel.cancelled() => Err(cancelled()),
+        result = work => Ok(result?),
+    }
+}
 
 #[derive(Deserialize)]
 struct Release {
@@ -66,10 +93,8 @@ fn client() -> Result<reqwest::Client> {
 }
 
 /// Asks what the newest release is. Reads only; installs nothing.
-pub async fn check() -> Result<Available> {
-    let response = client()?
-        .get(LATEST)
-        .send()
+pub async fn check(cancel: &CancellationToken) -> Result<Available> {
+    let response = interruptible(cancel, client()?.get(LATEST).send())
         .await
         .context("could not reach GitHub Releases")?;
     ensure!(
@@ -77,8 +102,7 @@ pub async fn check() -> Result<Available> {
         "GitHub Releases answered HTTP {}",
         response.status().as_u16()
     );
-    let release: Release = response
-        .json()
+    let release: Release = interruptible(cancel, response.json())
         .await
         .context("GitHub Releases returned something this version cannot read")?;
     let latest = release.tag_name.trim_start_matches('v').to_owned();
@@ -97,13 +121,21 @@ pub async fn check() -> Result<Available> {
     })
 }
 
-/// Runs the installer that release published. It writes the whole bundle to the
-/// same place the documented install command does, so an upgrade and a fresh
-/// install leave the machine in the same state.
-pub async fn install(available: &Available) -> Result<()> {
-    let response = client()?
-        .get(&available.installer)
-        .send()
+/// Where the running Cerul lives, so an upgrade replaces it rather than adding a
+/// copy somewhere else on PATH. `None` when the path cannot be resolved, which
+/// leaves the installer to its own default and leaves the result unverifiable.
+pub fn installed_at() -> Option<PathBuf> {
+    std::env::current_exe()
+        .ok()
+        .and_then(|path| path.canonicalize().ok())
+}
+
+/// Runs the installer that release published, into the directory the running
+/// program came from. Its output is captured rather than printed: this process
+/// owns its own streams, and a machine reading them is entitled to find only
+/// what Cerul wrote there.
+pub async fn install(available: &Available, cancel: &CancellationToken) -> Result<()> {
+    let response = interruptible(cancel, client()?.get(&available.installer).send())
         .await
         .context("could not download the installer")?;
     ensure!(
@@ -111,8 +143,7 @@ pub async fn install(available: &Available) -> Result<()> {
         "downloading the installer answered HTTP {}",
         response.status().as_u16()
     );
-    let script = response
-        .text()
+    let script = interruptible(cancel, response.text())
         .await
         .context("the installer did not read")?;
     // A redirect that lands on an error page is a page, not a script. Running it
@@ -122,6 +153,41 @@ pub async fn install(available: &Available) -> Result<()> {
         "what was downloaded is not a shell script; install manually from {}",
         available.installer
     );
+    // The last moment before anything is replaced. Someone who pressed Ctrl+C
+    // while this was downloading has already said no.
+    if cancel.is_cancelled() {
+        return Err(cancelled());
+    }
+    let executable = installed_at();
+    let directory = executable.as_ref().and_then(|path| path.parent());
+    run(&script, directory)?;
+    // The installer can only report where it wrote. Whether the command a shell
+    // will run next is the new one is a different question, and the only one
+    // worth answering, so it is asked of the file itself.
+    if let Some(path) = &executable {
+        let reported = std::process::Command::new(path)
+            .arg("--version")
+            .output()
+            .with_context(|| format!("could not run {} after installing", path.display()))?;
+        let reported = String::from_utf8_lossy(&reported.stdout);
+        let reported = reported.split_whitespace().nth(1).unwrap_or_default();
+        ensure!(
+            reported == available.latest,
+            "the installer finished, but {} still answers {}; install manually from {}",
+            path.display(),
+            match reported.is_empty() {
+                true => "nothing",
+                false => reported,
+            },
+            available.installer
+        );
+    }
+    Ok(())
+}
+
+/// Runs one installer script with its output captured, so a failure becomes an
+/// error of Cerul's own rather than text on streams that belong to a result.
+fn run(script: &str, directory: Option<&std::path::Path>) -> Result<()> {
     let mut file = tempfile::Builder::new()
         .prefix("cerul-installer-")
         .suffix(".sh")
@@ -129,24 +195,39 @@ pub async fn install(available: &Available) -> Result<()> {
         .context("could not write the installer to a temporary file")?;
     file.write_all(script.as_bytes())?;
     file.flush()?;
-    let status = std::process::Command::new("sh")
-        .arg(file.path())
-        .status()
-        .context("could not run the installer")?;
+    let mut command = std::process::Command::new("sh");
+    command.arg(file.path());
+    if let Some(directory) = directory {
+        command.env(INSTALL_DIR, directory);
+    }
+    let output = command.output().context("could not run the installer")?;
+    if output.status.success() {
+        return Ok(());
+    }
+    // What the installer said about its own failure is the useful part, and it
+    // was captured, so it has to be carried into the error rather than lost.
+    let said = [&output.stderr, &output.stdout]
+        .iter()
+        .map(|stream| String::from_utf8_lossy(stream).trim().to_owned())
+        .find(|text| !text.is_empty())
+        .unwrap_or_default();
+    let ending = output
+        .status
+        .code()
+        .map(|code| format!("exit {code}"))
+        .unwrap_or_else(|| "a signal".into());
+    let tail: Vec<&str> = said.lines().rev().take(3).collect();
     ensure!(
-        status.success(),
-        "the installer stopped with {}",
-        status
-            .code()
-            .map(|code| format!("exit {code}"))
-            .unwrap_or_else(|| "a signal".into())
+        said.is_empty(),
+        "the installer stopped with {ending}: {}",
+        tail.into_iter().rev().collect::<Vec<_>>().join(" · ")
     );
-    Ok(())
+    anyhow::bail!("the installer stopped with {ending}")
 }
 
 #[cfg(test)]
 mod tests {
-    use super::ordinal;
+    use super::{INSTALL_DIR, ordinal, run};
 
     #[test]
     fn versions_compare_by_number_rather_than_by_text() {
@@ -157,5 +238,38 @@ mod tests {
         // Nothing published carries a suffix, so it is ignored rather than
         // ranked by a rule nobody agreed on.
         assert_eq!(ordinal("0.0.7-rc1"), ordinal("0.0.7"));
+    }
+
+    /// The installer is a subprocess, and this process owns its own streams: a
+    /// machine reading them is entitled to find only what Cerul wrote there.
+    #[test]
+    fn the_installer_writes_to_no_stream_of_ours_and_its_failure_becomes_ours() {
+        let directory = tempfile::tempdir().unwrap();
+        let noisy = "#!/bin/sh\necho progress on stdout\necho detail on stderr >&2\n";
+        // A silent success: nothing was printed here, and nothing failed.
+        run(&format!("{noisy}exit 0\n"), None).unwrap();
+
+        let error = run(&format!("{noisy}echo 'no space left' >&2\nexit 3\n"), None)
+            .expect_err("a failing installer is a failure");
+        let text = format!("{error:#}");
+        assert!(text.contains("exit 3"), "{text}");
+        // What the installer said about its own failure is the useful part.
+        assert!(text.contains("no space left"), "{text}");
+
+        // Where it writes is where the running program already lives, so an
+        // upgrade replaces that copy instead of adding one somewhere else.
+        let seen = directory.path().join("seen");
+        run(
+            &format!(
+                "#!/bin/sh\nprintf '%s' \"${INSTALL_DIR}\" > {}\n",
+                seen.display()
+            ),
+            Some(directory.path()),
+        )
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&seen).unwrap(),
+            directory.path().to_string_lossy()
+        );
     }
 }


### PR DESCRIPTION
Nothing told a user that a newer Cerul existed, and nothing told them what to do about it. The install command has always doubled as the upgrade command, but no page said so, so somebody who installed once had no path forward.

## The command

```text
$ cerul upgrade
cerul 0.0.6 → 0.0.7 · the newest published release

  Runs       https://github.com/cerul-ai/cerul/releases/download/v0.0.7/cerul-installer.sh
  Replaces   cerul, cerul-ffmpeg, cerul-ffprobe
  Keeps      your workspace, saved key, and annotation files

Replace cerul 0.0.6 with 0.0.7? [y/N]
```

It asks GitHub what the newest release is and runs the installer **that release published**, not the one behind the permanent `latest` redirect, so the version it names and the version it installs are the same one.

Replacing the program is the only thing this CLI does that changes what answers the next command, so it is built to be refusable:

- It says what will run, what will be replaced, and what will be left alone before it asks.
- `--dry-run` reports and stops.
- `--json` reports and installs nothing. A machine reading a version number is not a decision to replace a binary; that needs `--yes`, as removal already does.
- A non-terminal caller must pass `--yes` rather than have the upgrade happen because nobody was there to say no.
- The downloaded script is checked for a shebang, so a redirect that lands on an error page is an error rather than something to execute.

Versions compare number by number, so 0.0.10 is newer than 0.0.9 where a string comparison says the opposite.

## Documentation

`docs/installation.md` gains an Upgrade section, all three READMEs gain a line beside the install command, and the agent skill learns that reporting is free while replacing the program is a decision to put to the user. `docs/agent.md` adds the response shape.

## Verification

Run against the live 0.0.7 release:

| Case | Result |
| --- | --- |
| Current build | `✓ cerul 0.0.7 is the newest release`, exit 0 |
| Built as 0.0.6, `--dry-run` | reports behind, installs nothing, exit 0 |
| Built as 0.0.6, `--json` | `"newer":true,"upgraded":false`, exit 0 |
| Built as 0.0.6, no terminal, no `--yes` | prints the plan, refuses, exit 2 |

Plus 118 tests, `cargo fmt --check`, strict clippy, generated schemas with no diff, and the documentation and source-package checks.

The install path itself was not executed, since running it would replace this machine's binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)