### PR TITLE
chore: prepare v0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cerul"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerul"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 license = "Apache-2.0"
 description = "Searchable video and annotation data, using your own model endpoints"

--- a/packaging/dist.toml
+++ b/packaging/dist.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerul"
-version = "0.0.7"
+version = "0.0.8"
 description = "Searchable video and annotation data, using your own model endpoints"
 license = "Apache-2.0 AND GPL-2.0-or-later AND Zlib"
 homepage = "https://cerul.ai"

--- a/skills/cerul/SKILL.md
+++ b/skills/cerul/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cerul
 description: Search local videos by meaning, exact words, or a reference image, and annotate actions, events, interactions, and states in videos or LeRobot demonstrations. Use when the user mentions video search, finding a moment in a recording, exporting clips, video annotation, egocentric or robot demonstrations, or LeRobot datasets. Requires the cerul command-line tool.
-generated-by: cerul 0.0.7
+generated-by: cerul 0.0.8
 generated-sha256: 5e32acf08e156e8e4969f4fd3dc79bab70bf0b95dc90d3bb4aaf620786ded8d8
 ---
 


### PR DESCRIPTION
Sets the version for the release that carries `cerul upgrade` from #259.

- Cargo.toml, Cargo.lock, and packaging/dist.toml agree on 0.0.8.
- `skills/cerul/SKILL.md` is regenerated: it records the version that wrote it and a digest of its own contents.

This is the first release an installed build can move on from without being told the install command again.

No behaviour changes. Verified locally: 119 tests, `cargo fmt --check`, strict clippy, generated schemas with no diff, and the documentation checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)