### PR TITLE
Configure optional ASR providers and fix audio indexing failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cerul"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerul"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2024"
 license = "Apache-2.0"
 description = "Searchable video and annotation data, using your own model endpoints"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -14,8 +14,8 @@ installation instructions are in the [documentation](docs/README.md).
 | Structure | Logic lives in library modules exposed through `lib.rs`. `main.rs` parses arguments, calls the library, and prints results. Desktop can link the library or consume subprocess JSON events without `serve`. |
 | Source of truth | One sidecar directory per episode, using JSONL and Parquet, **including embedding vectors**. Indexes are caches rebuildable from sidecars without model calls. |
 | Indexes | One LanceDB directory per `space_id`, the hash of provider kind, base URL, model, dimensions, and query instruction template. The same model name at different endpoints is a different space. Queries must match exactly. |
-| Endpoints | `embedding`, `vision`, and `transcription` support `kind = gemini \| openai` with user keys. `perception` is reserved and processing is not implemented. Missing perception must not block indexing/search. |
-| Default models | One Gemini key: `gemini-embedding-2` at 1536 dimensions and `gemini-3.8-flash`. |
+| Endpoints | The CLI fixes embedding to Gemini Embedding 2. Vision and optional transcription support `kind = gemini \| openai` with user keys. `perception` is reserved and processing is not implemented. Missing perception must not block indexing/search. |
+| Default models | Required Gemini embedding: `gemini-embedding-2` at 1536 dimensions. Vision: `gemini-3.8-flash`. Optional ASR preset: `gemini-3.5-transcribe`. |
 | OCR | Embedded PP-OCRv6 small, approximately 31 MB of weights, CPU inference through `tract-onnx`, enabled by default. This is the only embedded model and the only exception to endpoint-based inference. |
 | Retrieval | One multimodal space. Each 30-second unit has up to three independently embedded rows: video, transcript, screen text. The embedding endpoint must accept video and images; unsupported endpoints fail, without a text-only fallback. No BM25 or fusion. Exact strings use `--text` substring matching. Annotation filtering happens before vector search. |
 | Annotations | Three fixed families: `semantic`, `grounding`, `world`. Subtypes may grow. All derived records are annotations. |
@@ -130,7 +130,7 @@ Results: `hits[]` containing episode, stream, start_us, end_us, optional frame_r
 
 Return a workspace overview or an episode's annotation inventory. Running `cerul` without a command is equivalent to status.
 
-Ordinary status does not probe remote endpoints; remote capabilities are null (unknown). `--providers` probes embedding, vision, and transcription, plus perception only when explicitly configured, caching successful checks for seven days. `--recompute` refreshes checks; `--dry-run` performs none. Explicit probes report endpoint, model, check time, and error. Unsupported is false; missing keys and network errors remain null. Preserve other endpoint results when one fails and return exit code 6. The JSON root contains `capabilities`. Perception's advertised tasks do not imply that this version implements grounding/world.
+Ordinary status does not probe remote endpoints; remote capabilities are null (unknown). `--providers` probes embedding, vision, and enabled transcription, plus perception only when explicitly configured, caching successful checks for seven days. `--recompute` refreshes checks; `--dry-run` performs none. Explicit probes report endpoint, model, check time, and error. Unsupported is false; missing keys and network errors remain null. Preserve other endpoint results when one fails and return exit code 6. The JSON root contains `capabilities`. Perception's advertised tasks do not imply that this version implements grounding/world.
 
 ## 4. Configuration and models
 
@@ -143,7 +143,7 @@ secret values. Provider adapters must preserve these request contracts:
 | --- | --- | --- |
 | Embedding | `embedContent`, outputDimensionality=1536. Text query instruction: `task: search result \| query: {query}`. | `/v1/embeddings` with text, image, and video support. Reject text-only endpoints. |
 | Vision | `generateContent` with responseSchema. | `/v1/chat/completions` with image_url and json_schema. |
-| Transcription | Audio `generateContent` with a segment schema. | `/v1/audio/transcriptions`, verbose_json, segment timestamps. |
+| Transcription | Native word timestamps for `gemini-3.5-transcribe`; prompted segments for other Gemini models. | `/v1/audio/transcriptions`, verbose_json, segment timestamps. |
 
 Probe the remote calls actually needed, not command names. Index probes embedding only for pending vectors and transcription only for pending audio. Annotate probes selected vision/perception capabilities. Semantic search can refresh an expired embedding capability probe even when its query vector is cached. Filters alone, exact text, sidecar rebuilds, ordinary status, and cleanup make no probe calls.
 
@@ -286,3 +286,13 @@ capabilities from work excluded from this repository.
 
 Do not add speculative interface layers before a fifth station, second embedding
 provider, or fourth annotation family creates a concrete need.
+
+## Optional speech configuration
+
+`cerul config` selects Gemini, Groq, OpenAI, a custom OpenAI-compatible ASR, or
+Disabled. Interactive indexing offers this when audio is present and ASR settings
+or credentials are missing, not solely on first launch. Disabled is persisted;
+unconfigured speech is skipped without prompts in machine mode. Credentials are
+private and separate from model configuration. ASR failure retains searchable
+video/OCR vectors, records a diagnostic, and returns partial success. Repeating
+index resumes missing speech windows without recomputing completed OCR.

--- a/README.md
+++ b/README.md
@@ -153,3 +153,7 @@ Cerul's Rust code is Apache-2.0. Bundles also contain separately licensed media
 tools and OCR weights; see [third-party notices](THIRD_PARTY_NOTICES.md).
 The [Cerul name and logo](docs/assets/README.md) identify the project and do not
 imply endorsement of third-party products.
+
+Speech transcription is optional. Run `cerul config` to choose Gemini, Groq,
+OpenAI, a custom OpenAI-compatible service, or Disabled. Multimodal search uses
+Gemini Embedding 2 and requires a Gemini key. See [configuration](docs/configuration.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,23 +12,33 @@ Configuration priority, from lowest to highest:
 4. `CERUL_<ENDPOINT>_<FIELD>` environment variables.
 5. Repeated `--set KEY=TOML_VALUE` arguments.
 
-The default embedding model is `gemini-embedding-2` with 1536 dimensions; vision
-and transcription default to `gemini-3.8-flash`. These defaults use
-`GEMINI_API_KEY` and the Gemini v1beta endpoint. The [Gemini model reference](https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash)
-and [embedding guide](https://ai.google.dev/gemini-api/docs/embeddings) describe
-these model IDs. Text queries use the embedding guide's `task: search result | query: {query}`
-instruction. Use `cerul status --providers` to check access with your credentials.
-Transcription timestamps are model estimates; see [transcription](#provider-rate-limits-and-transcription).
-Store only the key's environment variable name in configuration, never the key.
+Multimodal embedding is fixed to `gemini-embedding-2`, 1536 dimensions, at the
+Google Gemini endpoint. A Gemini key is required for new vectors and semantic
+queries. Other embedding providers, models, dimensions, and URLs are rejected
+by the CLI. Offline status, cleanup, and rebuilding cached vectors need no key.
+Vision defaults to `gemini-3.8-flash`.
 
-The CLI can save a validated default Gemini key in `~/.cerul/credentials.json`
-(mode 0600). Stored keys are scoped to endpoint kind, service URL, and key
-variable name. Environment values override saved keys. `cerul auth` shows where
-the key would come from, `cerul auth set` enters and verifies one, and
-`cerul auth remove` deletes the saved copy. The first interactive processing
-command offers the same hidden setup when needed; JSON, quiet, yes, dry-run,
-and non-terminal calls never prompt. See [installation](installation.md) for
-storage, removal, and agent setup. Library callers do not read this file.
+Run `cerul config` to configure optional speech transcription. The same chooser
+appears when interactive indexing finds an audio track and missing ASR settings
+or credentials. Choose Gemini (reuse the Gemini key), Groq, OpenAI, Custom, or
+Disabled. Defaults are saved in `~/.cerul/config.toml`; an explicit Disabled
+choice is remembered. JSON, quiet, yes, dry-run, and redirected invocations never
+prompt. Unconfigured ASR is skipped in those modes. An enabled ASR that fails
+is reported as a partial result, not silently disabled.
+
+The presets are Gemini `gemini-3.5-transcribe`, Groq `whisper-large-v3-turbo`, and
+OpenAI `whisper-1`. Model names can be edited. Custom services need a base URL,
+model, and key, and must implement OpenAI's timestamped transcription contract.
+The setup check uses a silent audio clip; it checks connectivity and the response
+contract, not recognition accuracy. Use a real recording to evaluate accuracy.
+
+Keys are stored separately in `~/.cerul/credentials.json` (mode 0600), scoped to
+protocol, service URL, and environment variable name. Environment values override
+saved keys. Configuration files contain only the environment variable name,
+never the secret. `cerul auth set` and `cerul auth remove` continue to manage the
+Gemini key. Library callers do not read CLI credential storage.
+
+For non-interactive setup, export the selected key variable and configure ASR:
 
 ```toml
 [embedding]
@@ -43,17 +53,26 @@ base_url = "http://localhost:11434/v1"
 model = "qwen3-vl"
 
 [transcription]
+enabled = true
 kind = "openai"
 base_url = "https://api.groq.com/openai/v1"
 model = "whisper-large-v3-turbo"
 api_key_env = "GROQ_API_KEY"
 ```
 
-An OpenAI-compatible endpoint must implement the specific request and response
-features Cerul uses. Vision requires image input and structured JSON output;
-transcription requires timestamped segments. Embedding requires text, image,
-and video input in one matching space: a text-only embeddings endpoint is not a
-fallback. Compatibility is established by capability probes, not by its URL.
+To disable ASR permanently, set `enabled = false` in `[transcription]`. To use
+Gemini, set `kind = "gemini"`, `model = "gemini-3.5-transcribe"`,
+`base_url = "https://generativelanguage.googleapis.com/v1beta"`, and
+`api_key_env = "GEMINI_API_KEY"`. OpenAI uses `kind = "openai"`,
+`base_url = "https://api.openai.com/v1"`, `model = "whisper-1"`, and
+`api_key_env = "OPENAI_API_KEY"`.
+
+OpenAI-compatible ASR uses `/audio/transcriptions` with `verbose_json` and segment
+timestamps. A model returning text without timestamps is unsupported for video
+localization. Gemini's dedicated model uses native word annotations; other Gemini
+models retain the prompted segment-JSON compatibility path. No Responses API or
+cross-provider fallback is used. All results become the same integer-microsecond
+transcript sidecar format.
 
 Endpoint URLs cannot contain embedded credentials, query parameters, or
 fragments. For a command-line string override, include the TOML quotes:
@@ -68,7 +87,7 @@ Ordinary `status`, exact text search, annotation-only filters, index rebuilds,
 and cleanup do not probe providers. Commands probe only endpoints needed for
 pending work. Successful probes are cached for seven days.
 
-`cerul status --providers` explicitly probes embedding, vision, and transcription.
+`cerul status --providers` explicitly probes embedding, vision, and enabled transcription.
 Perception processing is not supported in this version. Its reserved endpoint
 is probed only when explicitly configured; otherwise its capability stays null
 and no request is sent to it. The command may return a partial result when one
@@ -96,10 +115,17 @@ Choose a limit appropriate for your provider account. Cerul honors bounded
 account quotas are available. A partial index retains completed work; repeat
 the same command after quota becomes available to fill the remaining units.
 
-Gemini transcription uses sixty-second audio windows and converts the model's
-clip-relative seconds to episode-relative integer microseconds. These are
-model-estimated speech boundaries; inspect the source video when exact word
-alignment matters.
+Transcription uses sixty-second audio windows and converts clip-relative times
+to episode-relative integer microseconds. Inspect the source when exact alignment
+matters. A failed ASR does not prevent video/OCR embedding publication. Repeat
+`cerul index ./recording.mp4` after fixing ASR to resume missing speech windows;
+completed OCR and compatible embedding checkpoints are reused. Changing the ASR
+model invalidates its transcript and the derived text embeddings.
+
+Skipping ASR omits the separate transcript; the video sent to the multimodal
+embedding service may still contain audio. JSON stream results include `speech`
+(`disabled`, `not_configured`, `no_audio`, `complete`, or `failed`). A partial
+failure returns exit 6 and retains a diagnostic in the stream's index state.
 
 ## Workspace and vector spaces
 
@@ -109,8 +135,7 @@ query template in its identity. Changing any of these requires compatible new
 vectors. `status` lists space IDs and public model metadata. A query cannot
 silently search a different space.
 
-Changing the embedding configuration invalidates embedding artifacts, while
-unchanged transcripts and OCR results remain reusable. Sidecar vectors are
+The CLI currently uses only the fixed Gemini embedding space. Sidecar vectors are
 retained by cache/index cleaning and can rebuild the corresponding index.
 
 ## Process contract

--- a/docs/development/validation.md
+++ b/docs/development/validation.md
@@ -15,6 +15,7 @@ cargo test --locked
 cargo run --locked --example generate_schemas -- --check
 python3 scripts/check-docs.py
 python3 -m unittest discover -s tests -p "test_documentation.py"
+CERUL_TEST_BINARY="$PWD/target/debug/cerul" python3 -m unittest discover -s tests -p "test_setup.py"
 cargo package --list --locked > /tmp/cerul-package-files.txt
 python3 scripts/check-docs.py --package-list /tmp/cerul-package-files.txt
 ```

--- a/docs/video-search.md
+++ b/docs/video-search.md
@@ -122,9 +122,11 @@ A truncated response and an empty or invalid JSON response have separate errors.
 Provider response text, credentials, and free-form rejection messages are not
 included in these diagnostics.
 
-Completed screen text and checkpoints remain available. Inspect the stored
-failure with `cerul status ./video.mp4 --json`. To save events and the final
-report from an explicitly requested rerun:
+Completed screen text and checkpoints remain available. For an incomplete
+index, inspect its saved failure with `cerul status ./video.mp4 --json`. If a
+`--recompute` attempt fails while an older complete index remains valid, status
+continues to describe that preserved index and does not retain the latest
+attempt's error. Capture the command report and events to keep that failure:
 
 ```sh
 cerul index ./video.mp4 --json > result.json 2> events.jsonl

--- a/docs/video-search.md
+++ b/docs/video-search.md
@@ -112,6 +112,13 @@ for endpoint selection and exit codes.
 For action labels in ordinary videos or demonstrations, see the
 [annotation guide](annotation.md).
 
+## Optional speech transcription
+
+Use `cerul config` to choose Gemini, Groq, OpenAI, or a custom transcription
+service. Choose Disabled to keep video embeddings and local OCR without a separate
+transcript. The chooser appears when indexing audio with missing ASR settings;
+non-interactive runs skip unconfigured ASR. See [configuration](configuration.md).
+
 ## Diagnose speech failures
 
 If Gemini blocks an audio request, Cerul reports the transcription window and
@@ -124,11 +131,10 @@ A truncated response and an empty or invalid JSON response have separate errors.
 Provider response text, credentials, and free-form rejection messages are not
 included in these diagnostics.
 
-Completed screen text and checkpoints remain available. For an incomplete
-index, inspect its saved failure with `cerul status ./video.mp4 --json`. If a
-`--recompute` attempt fails while an older complete index remains valid, status
-continues to describe that preserved index and does not retain the latest
-attempt's error. Capture the command report and events to keep that failure:
+Completed screen text and checkpoints remain available. Video/OCR vectors can
+remain searchable even when speech fails. Inspect the saved diagnostic with
+`cerul status ./video.mp4 --json`; a complete embedding state may carry a speech
+error. Capture the full command report and events for additional context:
 
 ```sh
 cerul index ./video.mp4 --json > result.json 2> events.jsonl

--- a/docs/video-search.md
+++ b/docs/video-search.md
@@ -111,3 +111,26 @@ for endpoint selection and exit codes.
 
 For action labels in ordinary videos or demonstrations, see the
 [annotation guide](annotation.md).
+
+## Diagnose speech failures
+
+If Gemini blocks an audio request, Cerul reports the transcription window and
+`promptFeedback.blockReason` or `finishReason`. `OTHER` is an unspecified
+provider rejection, not evidence of malformed JSON. Blocked responses are not
+automatically retried, and no successful transcript is published for them.
+A truncated response and an empty or invalid JSON response have separate errors.
+Provider response text, credentials, and free-form rejection messages are not
+included in these diagnostics.
+
+Completed screen text and checkpoints remain available. Inspect the stored
+failure with `cerul status ./video.mp4 --json`. To save events and the final
+report from an explicitly requested rerun:
+
+```sh
+cerul index ./video.mp4 --json > result.json 2> events.jsonl
+```
+
+Cerul does not automatically save a complete request/response log. Retrying can
+make new billable model calls. If speech is not needed, `cerul index ./video.mp4
+--no-audio` explicitly skips transcription; visual indexing still uses the
+configured embedding endpoint.

--- a/docs/video-search.md
+++ b/docs/video-search.md
@@ -115,8 +115,10 @@ For action labels in ordinary videos or demonstrations, see the
 ## Diagnose speech failures
 
 If Gemini blocks an audio request, Cerul reports the transcription window and
-`promptFeedback.blockReason` or `finishReason`. `OTHER` is an unspecified
-provider rejection, not evidence of malformed JSON. Blocked responses are not
+`promptFeedback.blockReason` or `finishReason`. In prompt feedback,
+`blockReason=OTHER` is an unspecified provider rejection, not evidence of
+malformed JSON. A candidate's `finishReason=OTHER` instead means an unknown
+completion reason; it does not establish that the request was blocked. Blocked responses are not
 automatically retried, and no successful transcript is published for them.
 A truncated response and an empty or invalid JSON response have separate errors.
 Provider response text, credentials, and free-form rejection messages are not

--- a/packaging/dist.toml
+++ b/packaging/dist.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerul"
-version = "0.0.8"
+version = "0.0.9"
 description = "Searchable video and annotation data, using your own model endpoints"
 license = "Apache-2.0 AND GPL-2.0-or-later AND Zlib"
 homepage = "https://cerul.ai"

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -42,6 +42,13 @@
           "format": "uint",
           "minimum": 0
         },
+        "enabled": {
+          "description": "None means speech has not been configured; false is an explicit opt-out.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "kind": {
           "type": "string"
         },

--- a/schemas/index-result.json
+++ b/schemas/index-result.json
@@ -45,6 +45,17 @@
         "streams"
       ]
     },
+    "SpeechStatus": {
+      "type": "string",
+      "enum": [
+        "disabled",
+        "not_configured",
+        "no_audio",
+        "complete",
+        "failed",
+        "planned"
+      ]
+    },
     "StreamResult": {
       "type": "object",
       "properties": {
@@ -56,6 +67,9 @@
         },
         "indexed": {
           "type": "boolean"
+        },
+        "speech": {
+          "$ref": "#/$defs/SpeechStatus"
         },
         "stream": {
           "type": "string"
@@ -69,6 +83,7 @@
       "required": [
         "stream",
         "indexed",
+        "speech",
         "vector_rows",
         "errors"
       ]

--- a/skills/cerul/SKILL.md
+++ b/skills/cerul/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cerul
 description: Search local videos by meaning, exact words, or a reference image, and annotate actions, events, interactions, and states in videos or LeRobot demonstrations. Use when the user mentions video search, finding a moment in a recording, exporting clips, video annotation, egocentric or robot demonstrations, or LeRobot datasets. Requires the cerul command-line tool.
-generated-by: cerul 0.0.8
+generated-by: cerul 0.0.9
 generated-sha256: 8c660268f2e72f9f3234723fa9ae5cfaafaea012901e247cab0b461065de6b17
 ---
 

--- a/skills/cerul/SKILL.md
+++ b/skills/cerul/SKILL.md
@@ -2,7 +2,7 @@
 name: cerul
 description: Search local videos by meaning, exact words, or a reference image, and annotate actions, events, interactions, and states in videos or LeRobot demonstrations. Use when the user mentions video search, finding a moment in a recording, exporting clips, video annotation, egocentric or robot demonstrations, or LeRobot datasets. Requires the cerul command-line tool.
 generated-by: cerul 0.0.8
-generated-sha256: 5e32acf08e156e8e4969f4fd3dc79bab70bf0b95dc90d3bb4aaf620786ded8d8
+generated-sha256: 8c660268f2e72f9f3234723fa9ae5cfaafaea012901e247cab0b461065de6b17
 ---
 
 # Cerul
@@ -193,6 +193,11 @@ Manage the saved Gemini API key
 
   cerul auth set                   Enter and verify a Gemini API key, replacing any saved one
   cerul auth remove                Delete the saved Gemini API key
+
+### cerul config
+
+Configure the required Gemini key and optional default speech transcription
+
 
 ### cerul annotate
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,9 @@ pub struct Endpoint {
     pub base_url: String,
     pub api_key_env: String,
     pub dims: Option<usize>,
+    /// None means speech has not been configured; false is an explicit opt-out.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -73,11 +76,12 @@ impl Default for Config {
             base_url: "https://generativelanguage.googleapis.com/v1beta".into(),
             api_key_env: "GEMINI_API_KEY".into(),
             dims,
+            enabled: None,
         };
         Self {
             embedding: endpoint("gemini-embedding-2", Some(1536)),
             vision: endpoint("gemini-3.8-flash", None),
-            transcription: endpoint("gemini-3.8-flash", None),
+            transcription: endpoint("gemini-3.5-transcribe", None),
             perception: Perception {
                 base_url: "https://api.cerul.ai".into(),
                 api_key_env: "CERUL_API_KEY".into(),
@@ -163,8 +167,17 @@ impl Config {
             }
         }
         for section in ["embedding", "vision", "transcription", "perception"] {
-            for field in ["kind", "model", "base_url", "api_key_env", "dims"] {
-                if section == "perception" && !matches!(field, "base_url" | "api_key_env") {
+            for field in [
+                "kind",
+                "model",
+                "base_url",
+                "api_key_env",
+                "dims",
+                "enabled",
+            ] {
+                if (field == "enabled" && section != "transcription")
+                    || (section == "perception" && !matches!(field, "base_url" | "api_key_env"))
+                {
                     continue;
                 }
                 let name = format!(
@@ -173,7 +186,12 @@ impl Config {
                     field.to_ascii_uppercase()
                 );
                 if let Some(raw) = environment.get(&name) {
-                    let value = if field == "dims" {
+                    let value = if field == "enabled" {
+                        toml::Value::Boolean(
+                            raw.parse()
+                                .with_context(|| format!("{name} must be true or false"))?,
+                        )
+                    } else if field == "dims" {
                         toml::Value::Integer(
                             raw.parse()
                                 .with_context(|| format!("{name} must be an integer"))?,
@@ -221,6 +239,14 @@ impl Config {
         merge(&mut defaults, explicit);
         let config: Self = defaults.try_into()?;
         config.validate()?;
+        let fixed = Self::default().embedding;
+        ensure!(
+            config.embedding.kind == fixed.kind
+                && config.embedding.model == fixed.model
+                && config.embedding.base_url.trim_end_matches('/') == fixed.base_url
+                && config.embedding.dims == fixed.dims,
+            "embedding is fixed to Gemini gemini-embedding-2 (1536 dimensions); only its credential setting can be changed"
+        );
         Ok(config)
     }
 
@@ -268,13 +294,34 @@ pub fn config_paths(home: &Path, cwd: &Path) -> [PathBuf; 2] {
 mod tests {
     use super::*;
     #[test]
+    fn speech_choice_is_distinct_from_missing_configuration() {
+        assert_eq!(Config::load(&[]).unwrap().transcription.enabled, None);
+        for enabled in [true, false] {
+            let config = Config::resolve(
+                &[],
+                &BTreeMap::new(),
+                toml::from_str(&format!("[transcription]\nenabled={enabled}\n")).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(config.transcription.enabled, Some(enabled));
+        }
+        assert!(
+            Config::resolve(
+                &[],
+                &BTreeMap::new(),
+                toml::from_str("[embedding]\nmodel='other'\n").unwrap()
+            )
+            .is_err()
+        );
+    }
+    #[test]
     fn precedence_and_provider_defaults_do_not_copy_credentials() {
         let dir = tempfile::tempdir().unwrap();
         let global = dir.path().join("global.toml");
         let project = dir.path().join("project.toml");
         fs::write(
             &global,
-            "[embedding]\ndims=768\n[vision]\nkind='openai'\nmodel='remote'\n",
+            "[embedding]\ndims=1536\n[vision]\nkind='openai'\nmodel='remote'\n",
         )
         .unwrap();
         fs::write(&project, "[vision]\nmodel='project'\n").unwrap();
@@ -289,7 +336,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(config.vision.model, "cli");
-        assert_eq!(config.embedding.dims, Some(768));
+        assert_eq!(config.embedding.dims, Some(1536));
         assert_eq!(config.vision.base_url, "https://api.openai.com/v1");
         assert_eq!(config.vision.api_key_env, "OPENAI_API_KEY");
         assert!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -239,14 +239,6 @@ impl Config {
         merge(&mut defaults, explicit);
         let config: Self = defaults.try_into()?;
         config.validate()?;
-        let fixed = Self::default().embedding;
-        ensure!(
-            config.embedding.kind == fixed.kind
-                && config.embedding.model == fixed.model
-                && config.embedding.base_url.trim_end_matches('/') == fixed.base_url
-                && config.embedding.dims == fixed.dims,
-            "embedding is fixed to Gemini gemini-embedding-2 (1536 dimensions); only its credential setting can be changed"
-        );
         Ok(config)
     }
 
@@ -311,7 +303,7 @@ mod tests {
                 &BTreeMap::new(),
                 toml::from_str("[embedding]\nmodel='other'\n").unwrap()
             )
-            .is_err()
+            .is_ok()
         );
     }
     #[test]
@@ -321,7 +313,7 @@ mod tests {
         let project = dir.path().join("project.toml");
         fs::write(
             &global,
-            "[embedding]\ndims=1536\n[vision]\nkind='openai'\nmodel='remote'\n",
+            "[embedding]\ndims=768\n[vision]\nkind='openai'\nmodel='remote'\n",
         )
         .unwrap();
         fs::write(&project, "[vision]\nmodel='project'\n").unwrap();
@@ -336,7 +328,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(config.vision.model, "cli");
-        assert_eq!(config.embedding.dims, Some(1536));
+        assert_eq!(config.embedding.dims, Some(768));
         assert_eq!(config.vision.base_url, "https://api.openai.com/v1");
         assert_eq!(config.vision.api_key_env, "OPENAI_API_KEY");
         assert!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,17 @@ pub struct Endpoint {
     pub enabled: Option<bool>,
 }
 
+impl Endpoint {
+    pub fn uses_native_transcription(&self) -> bool {
+        self.kind == "gemini"
+            && self
+                .model
+                .strip_prefix("models/")
+                .unwrap_or(&self.model)
+                .starts_with("gemini-3.5-transcribe")
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Perception {

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -66,15 +66,17 @@ pub fn resolver(
         let cancel = cancel.clone();
         Box::pin(async move {
             let mut stored = keys.lock().await;
-            if stored.is_none() {
-                *stored = Some(path().as_deref().map(read).transpose()?.unwrap_or_default());
-            }
+            *stored = Some(path().as_deref().map(read).transpose()?.unwrap_or_default());
             let keys = stored.as_mut().unwrap();
             let scope = credential_scope(&endpoint);
             if let Some(key) = keys.get(&scope) {
                 return Ok(Some(key.clone()));
             }
-            if !interactive {
+            if !interactive
+                || endpoint.kind != "gemini"
+                || endpoint.base_url.trim_end_matches('/')
+                    != "https://generativelanguage.googleapis.com/v1beta"
+            {
                 return Ok(None);
             }
             prompt(&endpoint, keys, cancel).await
@@ -131,27 +133,26 @@ async fn prompt(
     keys: &mut Keys,
     cancel: CancellationToken,
 ) -> Result<Option<String>> {
-    if endpoint.kind != "gemini"
-        || endpoint.base_url.trim_end_matches('/')
-            != "https://generativelanguage.googleapis.com/v1beta"
-    {
-        return Ok(None);
-    }
     let scope = credential_scope(endpoint);
     let path = path();
     let palette = crate::render::Palette::new(console::colors_enabled_stderr());
     eprintln!();
     eprintln!(
         "{}",
-        palette.bold("Cerul needs a Gemini API key for speech and semantic search.")
+        palette.bold(&format!(
+            "Configure {} at {}",
+            endpoint.model, endpoint.base_url
+        ))
     );
-    eprintln!("  Get one at https://aistudio.google.com/apikey");
+    if endpoint.kind == "gemini" {
+        eprintln!("  Get a key at https://aistudio.google.com/apikey");
+    }
     eprintln!(
         "  {}",
-        palette.dim("Stored privately in ~/.cerul/credentials.json. Gemini receives media during processing; API charges may apply.")
+        palette.dim("Stored privately in ~/.cerul/credentials.json. The selected service receives media during processing; API charges may apply.")
     );
-    let key = rpassword::prompt_password("Gemini API key (hidden, blank to cancel): ")
-        .inspect_err(|error| {
+    let key =
+        rpassword::prompt_password("API key (hidden, blank to cancel): ").inspect_err(|error| {
             if error.kind() == std::io::ErrorKind::Interrupted {
                 cancel.cancel();
             }
@@ -160,17 +161,31 @@ async fn prompt(
         cancel.cancel();
         anyhow::bail!("setup cancelled");
     }
-    eprint!(
-        "{}",
-        palette.dim("  checking the key with a small text request…")
-    );
-    let validation = cerul::config::Config::default().embedding;
+    eprintln!("  checking the configured endpoint…");
+    let mut validation = endpoint.clone();
+    if validation.kind == "gemini" && !validation.model.starts_with("gemini-3.5-transcribe") {
+        validation.model = "gemini-embedding-2".into();
+        validation.dims = Some(1536);
+    }
+    let embedding_check = validation.dims.is_some();
     let provider = Provider::new(validation, Some(key.trim().to_owned()), 1, None, cancel)?;
-    let checked = provider
-        .embed(Input::Text("Cerul setup".into()), true)
-        .await;
-    eprintln!();
-    checked.context("API key validation failed; key was not saved")?;
+    let checked = if embedding_check {
+        provider
+            .embed(Input::Text("Cerul setup".into()), true)
+            .await
+            .map(|_| ())
+    } else {
+        let workspace = tempfile::tempdir()?;
+        cerul::providers::probes::check(
+            &provider,
+            cerul::providers::probes::Capability::Transcription,
+            workspace.path(),
+            true,
+        )
+        .await
+        .map(|_| ())
+    };
+    checked.context("endpoint validation failed; key was not saved")?;
     keys.insert(scope, key.trim().to_owned());
     save(
         path.as_deref()

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -163,7 +163,7 @@ async fn prompt(
     }
     eprintln!("  checking the configured endpoint…");
     let mut validation = endpoint.clone();
-    if validation.kind == "gemini" && !validation.model.starts_with("gemini-3.5-transcribe") {
+    if validation.kind == "gemini" && !validation.uses_native_transcription() {
         validation.model = "gemini-embedding-2".into();
         validation.dims = Some(1536);
     }

--- a/src/index/pipeline.rs
+++ b/src/index/pipeline.rs
@@ -134,6 +134,42 @@ fn existing_annotation(
         Ok(None)
     }
 }
+fn retained_annotation(
+    sidecar: &Path,
+    episode: &Episode,
+    stream: &str,
+    name: &str,
+) -> Result<Option<AnnotationFile>> {
+    let Some(file) = existing_annotation(sidecar, episode, stream, name, false)? else {
+        return Ok(None);
+    };
+    if file.header.name != name
+        || file.header.stream != stream
+        || !stations::has_current_input(episode, &file)?
+    {
+        return Ok(None);
+    }
+    file.validate(episode.duration_us()?, None)?;
+    Ok(Some(file))
+}
+
+fn speech_plan(
+    episode: &Episode,
+    stream: &str,
+    disabled: bool,
+    enabled: Option<bool>,
+) -> Result<SpeechStatus> {
+    Ok(if disabled {
+        SpeechStatus::Disabled
+    } else if enabled.is_none() {
+        SpeechStatus::NotConfigured
+    } else if matches!(episode.video(stream)?, Stream::Video {probe, ..} if !probe.has_audio) {
+        SpeechStatus::NoAudio
+    } else {
+        SpeechStatus::Planned
+    })
+}
+
 fn interrupted(cancel: &CancellationToken) -> Result<()> {
     if cancel.is_cancelled() {
         return Err(ProviderError {
@@ -260,18 +296,25 @@ async fn run_inner(
             let sidecar =
                 discover::sidecar_path(&episode, &registry, options.sidecar_dir.as_deref())?;
             result.push(EpisodeResult {
-                episode_id: episode.episode_id,
+                episode_id: episode.episode_id.clone(),
                 sidecar,
                 streams: selected
                     .into_iter()
-                    .map(|stream| StreamResult {
-                        speech: SpeechStatus::Planned,
-                        stream,
-                        indexed: false,
-                        vector_rows: 0,
-                        errors: Vec::new(),
+                    .map(|stream| {
+                        Ok(StreamResult {
+                            speech: speech_plan(
+                                &episode,
+                                &stream,
+                                explicitly_disabled,
+                                config.transcription.enabled,
+                            )?,
+                            stream,
+                            indexed: false,
+                            vector_rows: 0,
+                            errors: Vec::new(),
+                        })
                     })
-                    .collect(),
+                    .collect::<Result<Vec<_>>>()?,
             });
         }
         return Ok(Report {
@@ -414,7 +457,7 @@ async fn run_inner(
         for stream in selected {
             interrupted(&cancel)?;
             let mut errors = Vec::new();
-            let screen = if options.no_ocr {
+            let mut screen = if options.no_ocr {
                 None
             } else {
                 match stations::screen_text(
@@ -433,7 +476,7 @@ async fn run_inner(
                     }
                 }
             };
-            let transcript = if options.no_audio {
+            let mut transcript = if options.no_audio {
                 None
             } else if let Some(error) = speech_blocked.get(&stream) {
                 errors.push(format!("speech: {error}"));
@@ -458,6 +501,15 @@ async fn run_inner(
                     }
                 }
             };
+            let speech_completed = transcript.is_some();
+            // Failed recomputation leaves the authoritative annotation intact. Reuse it
+            // only when it still belongs to this exact media input and stream.
+            if screen.is_none() && !options.no_ocr {
+                screen = retained_annotation(&sidecar, &episode, &stream, "screen_text")?;
+            }
+            if transcript.is_none() && !options.no_audio {
+                transcript = retained_annotation(&sidecar, &episode, &stream, "transcript")?;
+            }
             if let Some(error) = blocked.get(&stream) {
                 errors.push(error.clone());
             }
@@ -572,17 +624,15 @@ async fn run_inner(
                     }
                 }
             }
-            let speech = if explicitly_disabled {
-                SpeechStatus::Disabled
-            } else if config.transcription.enabled.is_none() {
-                SpeechStatus::NotConfigured
-            } else if matches!(episode.video(&stream)?, Stream::Video {probe, ..} if !probe.has_audio)
-            {
-                SpeechStatus::NoAudio
-            } else if transcript.is_some() {
-                SpeechStatus::Complete
-            } else {
-                SpeechStatus::Failed
+            let speech = match speech_plan(
+                &episode,
+                &stream,
+                explicitly_disabled,
+                config.transcription.enabled,
+            )? {
+                SpeechStatus::Planned if speech_completed => SpeechStatus::Complete,
+                SpeechStatus::Planned => SpeechStatus::Failed,
+                status => status,
             };
             result.streams.push(StreamResult {
                 speech,
@@ -755,6 +805,158 @@ mod tests {
                 .unwrap(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn failed_recompute_retains_speech_vectors_and_reports_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("audio.mp4");
+        crate::media::run(
+            crate::media::command("ffmpeg")
+                .args([
+                    "-v",
+                    "error",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "color=size=64x64:rate=2:duration=1",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "anullsrc=r=16000:cl=mono",
+                    "-t",
+                    "1",
+                    "-c:v",
+                    "libx264",
+                    "-c:a",
+                    "aac",
+                ])
+                .arg(&source),
+        )
+        .unwrap();
+        use serde_json::json;
+        let generated = |value: serde_json::Value| json!({"candidates":[{"content":{"parts":[{"text":value.to_string()}]}}]});
+        let (base, server) = crate::providers::tests::server(vec![
+            (200, generated(json!({"segments":[]}))),
+            (
+                200,
+                generated(
+                    json!({"segments":[{"start":0.1,"end":0.9,"text":"retained speech","lang":"en"}]}),
+                ),
+            ),
+            (200, json!({"promptFeedback":{"blockReason":"OTHER"}})),
+        ]);
+        let (embedding_base, embedding_server) =
+            crate::providers::tests::server(vec![
+                (200, json!({"embedding":{"values":[1.,0.]}}));
+                7
+            ]);
+        let mut config = Config::default();
+        config.embedding.base_url = embedding_base;
+        config.embedding.dims = Some(2);
+        config.transcription.base_url = base;
+        config.transcription.model = "gemini-3.8-flash".into();
+        config.transcription.enabled = Some(true);
+        let workspace = dir.path().join("workspace");
+        let mut options = Options {
+            no_ocr: true,
+            ..Default::default()
+        };
+        // Dry-run must describe the same effective speech choice without requests.
+        options.dry_run = true;
+        for (enabled, no_audio, expected) in [
+            (None, false, "not_configured"),
+            (Some(false), false, "disabled"),
+            (Some(true), true, "disabled"),
+            (Some(true), false, "planned"),
+        ] {
+            config.transcription.enabled = enabled;
+            options.no_audio = no_audio;
+            let result = run(
+                std::slice::from_ref(&source),
+                &workspace,
+                &config,
+                &options,
+                CancellationToken::new(),
+                &mut |_| {},
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                serde_json::to_value(&result.episodes[0].streams[0].speech).unwrap(),
+                expected
+            );
+        }
+        let mut silent_episode = discover::ordinary_episode(&source).unwrap();
+        if let Stream::Video { probe, .. } = &mut silent_episode.streams[0] {
+            probe.has_audio = false;
+        }
+        assert!(matches!(
+            speech_plan(&silent_episode, "primary", false, Some(true)).unwrap(),
+            SpeechStatus::NoAudio
+        ));
+        assert!(!workspace.exists());
+        config.transcription.enabled = Some(true);
+        options.no_audio = false;
+        options.dry_run = false;
+        let first = run(
+            std::slice::from_ref(&source),
+            &workspace,
+            &config,
+            &options,
+            CancellationToken::new(),
+            &mut |_| {},
+        )
+        .await
+        .unwrap();
+        assert!(!first.partial);
+        assert_eq!(first.episodes[0].streams[0].vector_rows, 2);
+        let sidecar = &first.episodes[0].sidecar;
+        let transcript = fs::read(sidecar.join("transcript.jsonl")).unwrap();
+        options.embedding.recompute = true;
+        let second = run(
+            std::slice::from_ref(&source),
+            &workspace,
+            &config,
+            &options,
+            CancellationToken::new(),
+            &mut |_| {},
+        )
+        .await
+        .unwrap();
+        assert!(second.partial);
+        assert!(matches!(
+            second.episodes[0].streams[0].speech,
+            SpeechStatus::Failed
+        ));
+        assert_eq!(second.episodes[0].streams[0].vector_rows, 2);
+        assert_eq!(
+            fs::read(sidecar.join("transcript.jsonl")).unwrap(),
+            transcript
+        );
+        let space = config.space_id().unwrap();
+        let rows = super::super::vectors::read(
+            &sidecar.join("embeddings").join(format!("{space}.parquet")),
+            2,
+        )
+        .unwrap();
+        assert!(rows.iter().any(|row| row.text == "retained speech"));
+        assert_eq!(
+            super::super::lance::VectorIndex::open(&workspace, &space, 2, false)
+                .await
+                .unwrap()
+                .count()
+                .await
+                .unwrap(),
+            2
+        );
+        let state: embed::State = serde_json::from_slice(
+            &fs::read(embed::state_path(sidecar, "primary", "primary", &space)).unwrap(),
+        )
+        .unwrap();
+        assert!(state.complete && state.error.is_some());
+        assert_eq!(server.join().unwrap().len(), 3);
+        assert_eq!(embedding_server.join().unwrap().len(), 7);
     }
 
     #[tokio::test]

--- a/src/index/pipeline.rs
+++ b/src/index/pipeline.rs
@@ -61,9 +61,20 @@ pub struct EpisodeResult {
     pub streams: Vec<StreamResult>,
 }
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SpeechStatus {
+    Disabled,
+    NotConfigured,
+    NoAudio,
+    Complete,
+    Failed,
+    Planned,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct StreamResult {
     pub stream: String,
     pub indexed: bool,
+    pub speech: SpeechStatus,
     pub vector_rows: usize,
     pub errors: Vec<String>,
 }
@@ -134,6 +145,49 @@ fn interrupted(cancel: &CancellationToken) -> Result<()> {
     Ok(())
 }
 
+/// Read-only planning for a CLI deciding whether missing speech settings are relevant.
+/// A fully cached transcript never requires a key just to rebuild an index.
+pub fn pending_transcription(
+    paths: &[PathBuf],
+    workspace: &Path,
+    config: &Config,
+    options: &Options,
+) -> Result<bool> {
+    let registry = discover::read_registry(workspace)?;
+    let provider = Provider::new(
+        config.transcription.clone(),
+        None,
+        1,
+        None,
+        CancellationToken::new(),
+    )?;
+    for input in discover::discover(paths)? {
+        let episodes = match input {
+            Input::Video(path) => vec![discover::ordinary_episode(&path)?],
+            Input::LeRobot(path) => crate::lerobot::read(&path)?,
+        };
+        for episode in episodes {
+            if !selected(&episode, options.only.as_deref()) {
+                continue;
+            }
+            let sidecar =
+                discover::sidecar_path(&episode, &registry, options.sidecar_dir.as_deref())?;
+            for stream in streams(&episode, &options.streams)? {
+                if stations::transcript_pending(
+                    &episode,
+                    &stream,
+                    &sidecar,
+                    &provider,
+                    options.embedding.recompute,
+                )? {
+                    return Ok(true);
+                }
+            }
+        }
+    }
+    Ok(false)
+}
+
 pub async fn run(
     paths: &[PathBuf],
     workspace: &Path,
@@ -158,6 +212,10 @@ async fn run_inner(
     events: &mut dyn EventSink,
 ) -> Result<Report> {
     config.validate()?;
+    let mut effective = options.clone();
+    let explicitly_disabled = options.no_audio || config.transcription.enabled == Some(false);
+    effective.no_audio |= config.transcription.enabled != Some(true);
+    let options = &effective;
     ensure!(
         options.jobs > 0 && options.rpm != Some(0),
         "jobs and RPM must be positive"
@@ -207,6 +265,7 @@ async fn run_inner(
                 streams: selected
                     .into_iter()
                     .map(|stream| StreamResult {
+                        speech: SpeechStatus::Planned,
                         stream,
                         indexed: false,
                         vector_rows: 0,
@@ -266,6 +325,7 @@ async fn run_inner(
             &discover::read_registry(workspace)?,
             options.sidecar_dir.as_deref(),
         )?;
+        let mut speech_blocked = std::collections::BTreeMap::new();
         // Probe only uncached audio work, before OCR. Offline endpoints may still
         // leave useful local output; unsupported protocols and credentials are hard errors.
         if !options.no_audio {
@@ -288,11 +348,16 @@ async fn run_inner(
                 .await
                 {
                     Ok(_) => {}
-                    Err(error)
-                        if error.downcast_ref::<ProviderError>().is_some_and(|e| {
-                            matches!(e.kind, Failure::Unavailable | Failure::MissingKey)
-                        }) => {}
-                    Err(error) => return Err(error),
+                    Err(error) if cancel.is_cancelled() => return Err(error),
+                    Err(error) => {
+                        speech_blocked.insert(
+                            stream.clone(),
+                            format!(
+                                "model {} at {}: {error}",
+                                transcription.endpoint.model, transcription.endpoint.base_url
+                            ),
+                        );
+                    }
                 }
             }
         }
@@ -329,9 +394,9 @@ async fn run_inner(
                 {
                     Ok(_) => {}
                     Err(error)
-                        if error.downcast_ref::<ProviderError>().is_some_and(|e| {
-                            matches!(e.kind, Failure::Unavailable | Failure::MissingKey)
-                        }) =>
+                        if error
+                            .downcast_ref::<ProviderError>()
+                            .is_some_and(|e| matches!(e.kind, Failure::Unavailable)) =>
                     {
                         blocked.insert(stream.clone(), error.to_string());
                     }
@@ -370,6 +435,9 @@ async fn run_inner(
             };
             let transcript = if options.no_audio {
                 None
+            } else if let Some(error) = speech_blocked.get(&stream) {
+                errors.push(format!("speech: {error}"));
+                None
             } else {
                 match stations::transcript(
                     &episode,
@@ -383,16 +451,7 @@ async fn run_inner(
                 .await
                 {
                     Ok(file) => Some(file),
-                    Err(error)
-                        if error.downcast_ref::<ProviderError>().is_some_and(|e| {
-                            matches!(
-                                e.kind,
-                                Failure::Unsupported | Failure::MissingKey | Failure::Cancelled
-                            )
-                        }) =>
-                    {
-                        return Err(error);
-                    }
+                    Err(error) if cancel.is_cancelled() => return Err(error),
                     Err(error) => {
                         errors.push(error.to_string());
                         None
@@ -402,7 +461,8 @@ async fn run_inner(
             if let Some(error) = blocked.get(&stream) {
                 errors.push(error.clone());
             }
-            let count = if errors.is_empty() {
+            let mut embedding_succeeded = false;
+            let count = if !blocked.contains_key(&stream) {
                 match embed::run(
                     &episode,
                     &stream,
@@ -417,7 +477,10 @@ async fn run_inner(
                 )
                 .await
                 {
-                    Ok(count) => count,
+                    Ok(count) => {
+                        embedding_succeeded = true;
+                        count
+                    }
                     Err(error)
                         if error.downcast_ref::<ProviderError>().is_some_and(|e| {
                             matches!(
@@ -465,16 +528,21 @@ async fn run_inner(
                 )?;
                 let preserve = if state_path.is_file() {
                     let state: embed::State = serde_json::from_slice(&fs::read(&state_path)?)?;
-                    state.complete
-                        && state.input_hash == input_hash
-                        && sidecar
-                            .join("embeddings")
-                            .join(format!("{space}.parquet"))
-                            .is_file()
+                    embedding_succeeded
+                        || (state.complete
+                            && state.input_hash == input_hash
+                            && sidecar
+                                .join("embeddings")
+                                .join(format!("{space}.parquet"))
+                                .is_file())
                 } else {
                     false
                 };
-                if !preserve {
+                if preserve {
+                    let mut state: embed::State = serde_json::from_slice(&fs::read(&state_path)?)?;
+                    state.error = Some(errors.join("; "));
+                    storage::write_json(&state_path, &state)?;
+                } else {
                     storage::write_json(
                         &state_path,
                         &embed::State {
@@ -495,9 +563,31 @@ async fn run_inner(
                     msg: format!("{} {stream}: {}", episode.episode_id, errors.join("; ")),
                 });
             }
+            if errors.is_empty() {
+                let path = embed::state_path(&sidecar, &stream, &episode.time.reference, &space);
+                if path.is_file() {
+                    let mut state: embed::State = serde_json::from_slice(&fs::read(&path)?)?;
+                    if state.error.take().is_some() {
+                        storage::write_json(&path, &state)?;
+                    }
+                }
+            }
+            let speech = if explicitly_disabled {
+                SpeechStatus::Disabled
+            } else if config.transcription.enabled.is_none() {
+                SpeechStatus::NotConfigured
+            } else if matches!(episode.video(&stream)?, Stream::Video {probe, ..} if !probe.has_audio)
+            {
+                SpeechStatus::NoAudio
+            } else if transcript.is_some() {
+                SpeechStatus::Complete
+            } else {
+                SpeechStatus::Failed
+            };
             result.streams.push(StreamResult {
+                speech,
                 stream,
-                indexed: errors.is_empty(),
+                indexed: embedding_succeeded,
                 vector_rows: count,
                 errors,
             });
@@ -668,7 +758,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unsupported_transcription_fails_before_ocr_or_sidecar_publication() {
+    async fn unsupported_transcription_keeps_video_searchable() {
         let dir = tempfile::tempdir().unwrap();
         let source = dir.path().join("audio.mp4");
         crate::media::run(
@@ -700,23 +790,87 @@ mod tests {
         )]);
         let mut config = Config::default();
         config.transcription.base_url = base;
+        config.transcription.enabled = Some(true);
+        config.transcription.model = "gemini-3.8-flash".into();
+        let (embedding_base, embedding_server) = crate::providers::tests::server(vec![
+            (
+                200,
+                serde_json::json!({"embedding":{"values":[1.,0.]}})
+            );
+            4
+        ]);
+        config.embedding.base_url = embedding_base;
+        config.embedding.dims = Some(2);
         let workspace = dir.path().join("workspace");
-        let error = run(
-            &[source],
+        let report = run(
+            std::slice::from_ref(&source),
             &workspace,
             &config,
-            &Options::default(),
+            &Options {
+                no_ocr: true,
+                ..Default::default()
+            },
             CancellationToken::new(),
             &mut |_| {},
         )
         .await
-        .unwrap_err();
-        assert_eq!(
-            error.downcast_ref::<ProviderError>().unwrap().kind,
-            Failure::Unsupported
-        );
+        .unwrap();
+        assert!(report.partial);
+        assert!(report.episodes[0].streams[0].indexed);
+        assert_eq!(report.episodes[0].streams[0].vector_rows, 1);
         assert_eq!(server.join().unwrap().len(), 1);
-        assert!(discover::read_registry(&workspace).unwrap().is_empty());
+        assert_eq!(embedding_server.join().unwrap().len(), 4);
+        let state: embed::State = serde_json::from_slice(
+            &fs::read(embed::state_path(
+                &report.episodes[0].sidecar,
+                "primary",
+                "primary",
+                &config.space_id().unwrap(),
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(state.complete);
+        assert!(state.error.is_some());
+        assert_eq!(
+            super::super::lance::VectorIndex::open(
+                &workspace,
+                &config.space_id().unwrap(),
+                2,
+                false
+            )
+            .await
+            .unwrap()
+            .count()
+            .await
+            .unwrap(),
+            1
+        );
+        // Disabling or leaving ASR unconfigured reuses the completed video index offline.
+        for enabled in [Some(false), None] {
+            config.transcription.enabled = enabled;
+            let report = run(
+                std::slice::from_ref(&source),
+                &workspace,
+                &config,
+                &Options {
+                    no_ocr: true,
+                    ..Default::default()
+                },
+                CancellationToken::new(),
+                &mut |_| {},
+            )
+            .await
+            .unwrap();
+            assert!(!report.partial);
+            let stream = &report.episodes[0].streams[0];
+            assert!(stream.indexed);
+            assert_eq!(stream.vector_rows, 1);
+            assert!(matches!(
+                (&stream.speech, enabled),
+                (SpeechStatus::Disabled, Some(false)) | (SpeechStatus::NotConfigured, None)
+            ));
+        }
     }
     #[tokio::test]
     async fn offline_index_preserves_local_ocr_and_reports_incomplete_embedding() {

--- a/src/index/pipeline.rs
+++ b/src/index/pipeline.rs
@@ -373,6 +373,14 @@ async fn run_inner(
         // leave useful local output; unsupported protocols and credentials are hard errors.
         if !options.no_audio {
             for stream in &selected {
+                if options.embedding.recompute {
+                    stations::begin_transcript_recompute(
+                        &episode,
+                        stream,
+                        &planned,
+                        &transcription,
+                    )?;
+                }
                 if !stations::transcript_pending(
                     &episode,
                     stream,
@@ -845,6 +853,12 @@ mod tests {
                 ),
             ),
             (200, json!({"promptFeedback":{"blockReason":"OTHER"}})),
+            (
+                200,
+                generated(
+                    json!({"segments":[{"start":0.1,"end":0.9,"text":"retained speech","lang":"en"}]}),
+                ),
+            ),
         ]);
         let (embedding_base, embedding_server) =
             crate::providers::tests::server(vec![
@@ -955,7 +969,23 @@ mod tests {
         )
         .unwrap();
         assert!(state.complete && state.error.is_some());
-        assert_eq!(server.join().unwrap().len(), 3);
+        options.embedding.recompute = false;
+        let recovered = run(
+            std::slice::from_ref(&source),
+            &workspace,
+            &config,
+            &options,
+            CancellationToken::new(),
+            &mut |_| {},
+        )
+        .await
+        .unwrap();
+        assert!(!recovered.partial);
+        assert!(matches!(
+            recovered.episodes[0].streams[0].speech,
+            SpeechStatus::Complete
+        ));
+        assert_eq!(server.join().unwrap().len(), 4);
         assert_eq!(embedding_server.join().unwrap().len(), 7);
     }
 

--- a/src/index/stations.rs
+++ b/src/index/stations.rs
@@ -390,9 +390,12 @@ pub async fn transcript(
                         )?,
                         &audio,
                     )?;
-                    let response = provider
+                    let records = provider
                         .transcribe(fs::read(audio)?, window.end_us - window.start_us)
                         .await
+                        .and_then(|response| {
+                            probes::segments(response, window.end_us - window.start_us)
+                        })
                         .map_err(|error| {
                             let message = format!(
                                 "speech transcription window {} ({}-{}s): {error}",
@@ -411,7 +414,6 @@ pub async fn transcript(
                                 anyhow::anyhow!(message)
                             }
                         })?;
-                    let records = probes::segments(response, window.end_us - window.start_us)?;
                     checkpoints.save(&checkpoint, &records)?;
                     records
                 }
@@ -501,7 +503,7 @@ pub fn text_for_range(
 mod tests {
     use super::*;
     #[tokio::test]
-    async fn blocked_transcription_reports_window_without_publishing_success() {
+    async fn failed_transcription_reports_window_without_publishing_success() {
         let dir = tempfile::tempdir().unwrap();
         let video = dir.path().join("speech.mp4");
         media::run(
@@ -526,53 +528,69 @@ mod tests {
                 .arg(&video),
         )
         .unwrap();
-        let (base, server) = crate::providers::tests::server(vec![
+        for (case, response, detail) in [
             (
-                200,
-                json!({"candidates":[{"content":{"parts":[{"text":"{\"segments\":[]}"}]}}]}),
+                "blocked",
+                json!({"promptFeedback":{"blockReason":"OTHER"}}),
+                "blockReason=OTHER",
             ),
-            (200, json!({"promptFeedback":{"blockReason":"OTHER"}})),
-        ]);
-        let mut endpoint = crate::config::Config::default().transcription;
-        endpoint.base_url = base;
-        let provider = Provider::new(
-            endpoint,
-            None,
-            1,
-            None,
-            tokio_util::sync::CancellationToken::new(),
-        )
-        .unwrap();
-        let episode = crate::index::discover::ordinary_episode(&video).unwrap();
-        let workspace = dir.path().join("workspace");
-        let sidecar = crate::index::discover::publish_episode(&workspace, &episode, None).unwrap();
-        let error = transcript(
-            &episode,
-            "primary",
-            &sidecar,
-            &workspace,
-            &provider,
-            false,
-            &mut |_| {},
-        )
-        .await
-        .unwrap_err();
-        assert_eq!(
-            error
-                .downcast_ref::<crate::providers::ProviderError>()
-                .unwrap()
-                .kind,
-            crate::providers::Failure::Rejected
-        );
-        assert!(
-            error
-                .to_string()
-                .contains("speech transcription window 1 (0.000000-2.000000s)"),
-            "{error}"
-        );
-        assert!(error.to_string().contains("blockReason=OTHER"));
-        assert!(!sidecar.join("transcript.jsonl").exists());
-        assert_eq!(server.join().unwrap().len(), 2);
+            (
+                "invalid-segment",
+                json!({"candidates":[{"content":{"parts":[{"text":json!({"segments":[{"start":0,"end":10,"text":"hello","lang":"en"}]}).to_string()}]}}]}),
+                "transcript segment exceeds clip duration",
+            ),
+        ] {
+            let (base, server) = crate::providers::tests::server(vec![
+                (
+                    200,
+                    json!({"candidates":[{"content":{"parts":[{"text":"{\"segments\":[]}"}]}}]}),
+                ),
+                (200, response),
+            ]);
+            let mut endpoint = crate::config::Config::default().transcription;
+            endpoint.base_url = base;
+            let provider = Provider::new(
+                endpoint,
+                None,
+                1,
+                None,
+                tokio_util::sync::CancellationToken::new(),
+            )
+            .unwrap();
+            let episode = crate::index::discover::ordinary_episode(&video).unwrap();
+            let workspace = dir.path().join(case);
+            let sidecar =
+                crate::index::discover::publish_episode(&workspace, &episode, None).unwrap();
+            let error = transcript(
+                &episode,
+                "primary",
+                &sidecar,
+                &workspace,
+                &provider,
+                false,
+                &mut |_| {},
+            )
+            .await
+            .unwrap_err();
+            if case == "blocked" {
+                assert_eq!(
+                    error
+                        .downcast_ref::<crate::providers::ProviderError>()
+                        .unwrap()
+                        .kind,
+                    crate::providers::Failure::Rejected
+                );
+            }
+            assert!(
+                error
+                    .to_string()
+                    .contains("speech transcription window 1 (0.000000-2.000000s)"),
+                "{error}"
+            );
+            assert!(error.to_string().contains(detail), "{error}");
+            assert!(!sidecar.join("transcript.jsonl").exists());
+            assert_eq!(server.join().unwrap().len(), 2);
+        }
     }
 
     #[tokio::test]

--- a/src/index/stations.rs
+++ b/src/index/stations.rs
@@ -392,7 +392,25 @@ pub async fn transcript(
                     )?;
                     let response = provider
                         .transcribe(fs::read(audio)?, window.end_us - window.start_us)
-                        .await?;
+                        .await
+                        .map_err(|error| {
+                            let message = format!(
+                                "speech transcription window {} ({}-{}s): {error}",
+                                index + 1,
+                                media::seconds(window.start_us),
+                                media::seconds(window.end_us)
+                            );
+                            if let Some(provider_error) =
+                                error.downcast_ref::<crate::providers::ProviderError>()
+                            {
+                                anyhow::Error::new(crate::providers::ProviderError {
+                                    kind: provider_error.kind,
+                                    message,
+                                })
+                            } else {
+                                anyhow::anyhow!(message)
+                            }
+                        })?;
                     let records = probes::segments(response, window.end_us - window.start_us)?;
                     checkpoints.save(&checkpoint, &records)?;
                     records
@@ -482,6 +500,81 @@ pub fn text_for_range(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[tokio::test]
+    async fn blocked_transcription_reports_window_without_publishing_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let video = dir.path().join("speech.mp4");
+        media::run(
+            crate::media::command("ffmpeg")
+                .args([
+                    "-v",
+                    "error",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "color=size=32x32:rate=1:duration=2",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "sine=frequency=440:sample_rate=16000:duration=2",
+                    "-c:v",
+                    "libx264",
+                    "-c:a",
+                    "aac",
+                    "-shortest",
+                ])
+                .arg(&video),
+        )
+        .unwrap();
+        let (base, server) = crate::providers::tests::server(vec![
+            (
+                200,
+                json!({"candidates":[{"content":{"parts":[{"text":"{\"segments\":[]}"}]}}]}),
+            ),
+            (200, json!({"promptFeedback":{"blockReason":"OTHER"}})),
+        ]);
+        let mut endpoint = crate::config::Config::default().transcription;
+        endpoint.base_url = base;
+        let provider = Provider::new(
+            endpoint,
+            None,
+            1,
+            None,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .unwrap();
+        let episode = crate::index::discover::ordinary_episode(&video).unwrap();
+        let workspace = dir.path().join("workspace");
+        let sidecar = crate::index::discover::publish_episode(&workspace, &episode, None).unwrap();
+        let error = transcript(
+            &episode,
+            "primary",
+            &sidecar,
+            &workspace,
+            &provider,
+            false,
+            &mut |_| {},
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            error
+                .downcast_ref::<crate::providers::ProviderError>()
+                .unwrap()
+                .kind,
+            crate::providers::Failure::Rejected
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("speech transcription window 1 (0.000000-2.000000s)"),
+            "{error}"
+        );
+        assert!(error.to_string().contains("blockReason=OTHER"));
+        assert!(!sidecar.join("transcript.jsonl").exists());
+        assert_eq!(server.join().unwrap().len(), 2);
+    }
+
     #[tokio::test]
     async fn ten_minute_audio_uses_bounded_requests_and_offsets_segment_times_once() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/index/stations.rs
+++ b/src/index/stations.rs
@@ -286,7 +286,7 @@ pub fn screen_text(
 
 const WINDOW_US: i64 = 60_000_000;
 fn transcript_params(provider: &Provider) -> serde_json::Value {
-    json!({"kind":provider.endpoint.kind,"model":provider.endpoint.model,"base_url":provider.endpoint.base_url,"window_us":WINDOW_US,"timestamp_protocol":if provider.endpoint.kind == "gemini" && provider.endpoint.model.starts_with("gemini-3.5-transcribe") {"native-word-phrases/1"} else {"seconds/1"}})
+    json!({"kind":provider.endpoint.kind,"model":provider.endpoint.model,"base_url":provider.endpoint.base_url,"window_us":WINDOW_US,"timestamp_protocol":if provider.endpoint.kind == "gemini" && provider.endpoint.model.starts_with("gemini-3.5-transcribe") {"native-word-phrases/2"} else {"seconds/1"}})
 }
 fn transcript_key(episode: &Episode, stream: &str, provider: &Provider) -> Result<String> {
     // Short audio windows avoid long-context timestamp drift and keep inline

--- a/src/index/stations.rs
+++ b/src/index/stations.rs
@@ -286,13 +286,34 @@ pub fn screen_text(
 
 const WINDOW_US: i64 = 60_000_000;
 fn transcript_params(provider: &Provider) -> serde_json::Value {
-    json!({"kind":provider.endpoint.kind,"model":provider.endpoint.model,"base_url":provider.endpoint.base_url,"window_us":WINDOW_US,"timestamp_protocol":if provider.endpoint.kind == "gemini" && provider.endpoint.model.starts_with("gemini-3.5-transcribe") {"native-word-phrases/2"} else {"seconds/1"}})
+    json!({"kind":provider.endpoint.kind,"model":provider.endpoint.model,"base_url":provider.endpoint.base_url,"window_us":WINDOW_US,"timestamp_protocol":if provider.endpoint.uses_native_transcription() {"native-word-phrases/2"} else {"seconds/1"}})
 }
 fn transcript_key(episode: &Episode, stream: &str, provider: &Provider) -> Result<String> {
     // Short audio windows avoid long-context timestamp drift and keep inline
     // mono 16 kHz PCM requests well below the encoded request-size limit.
     let params = transcript_params(provider);
     station_key(episode, stream, "transcript", &params)
+}
+
+// A recomputation gets its own resumable checkpoint generation. The marker remains
+// until publication succeeds, even when the previous authoritative file is retained.
+fn retry_path(sidecar: &Path, key: &str) -> PathBuf {
+    sidecar
+        .join("staging/checkpoints")
+        .join(format!("transcript-{key}.pending"))
+}
+pub(crate) fn begin_transcript_recompute(
+    episode: &Episode,
+    stream: &str,
+    sidecar: &Path,
+    provider: &Provider,
+) -> Result<()> {
+    let key = transcript_key(episode, stream, provider)?;
+    let generation = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_nanos()
+        .to_string();
+    storage::atomic_write(&retry_path(sidecar, &key), generation.as_bytes())
 }
 
 pub fn transcript_pending(
@@ -313,6 +334,9 @@ pub fn transcript_pending(
     }
     let key = transcript_key(episode, stream, provider)?;
     let path = stream_directory(sidecar, stream, &episode.time.reference).join("transcript.jsonl");
+    if retry_path(sidecar, &key).is_file() {
+        return Ok(true);
+    }
     if existing(&path, &key, episode.duration_us()?, recompute)?.is_some() {
         return Ok(false);
     }
@@ -345,7 +369,15 @@ pub async fn transcript(
     let duration = episode.duration_us()?;
     let directory = stream_directory(sidecar, stream, &episode.time.reference);
     let path = directory.join("transcript.jsonl");
-    if let Some(file) = existing(&path, &key, duration, recompute)? {
+    let pending = retry_path(sidecar, &key);
+    if recompute && !pending.is_file() {
+        begin_transcript_recompute(episode, stream, sidecar, provider)?;
+    }
+    let generation = pending
+        .is_file()
+        .then(|| fs::read_to_string(&pending))
+        .transpose()?;
+    if let Some(file) = existing(&path, &key, duration, recompute || generation.is_some())? {
         return Ok(file);
     }
     let Stream::Video {
@@ -363,8 +395,11 @@ pub async fn transcript(
         let checkpoints = Checkpoints::new(sidecar);
         let windows = media::chunks(range_us[1] - range_us[0], WINDOW_US, 0)?;
         for (index, window) in windows.iter().enumerate() {
-            let checkpoint = storage::cache_key(&(&key, window))?;
-            let cached = if !recompute {
+            let checkpoint = match &generation {
+                Some(generation) => storage::cache_key(&(&key, window, generation))?,
+                None => storage::cache_key(&(&key, window))?,
+            };
+            let cached = if !recompute || generation.is_some() {
                 checkpoints.load::<Vec<Record>>(&checkpoint)?
             } else {
                 None
@@ -476,7 +511,27 @@ pub async fn transcript(
             "upstream transcript changed; run index to refresh vectors",
         )?;
     }
+    // Promote only a complete generation, so later checkpoint-only reconstruction
+    // cannot resurrect the transcript from before the successful recomputation.
+    if let Some(generation) = &generation {
+        let checkpoints = Checkpoints::new(sidecar);
+        for window in media::chunks(range_us[1] - range_us[0], WINDOW_US, 0)? {
+            if let Some(records) = checkpoints.load::<Vec<Record>>(&storage::cache_key(&(
+                &file.header.input_hash,
+                window,
+                generation,
+            ))?)? {
+                checkpoints.save(
+                    &storage::cache_key(&(&file.header.input_hash, window))?,
+                    &records,
+                )?;
+            }
+        }
+    }
     file.publish(&path, duration, None)?;
+    if generation.is_some() {
+        fs::remove_file(pending)?;
+    }
     Ok(file)
 }
 

--- a/src/index/stations.rs
+++ b/src/index/stations.rs
@@ -286,7 +286,7 @@ pub fn screen_text(
 
 const WINDOW_US: i64 = 60_000_000;
 fn transcript_params(provider: &Provider) -> serde_json::Value {
-    json!({"kind":provider.endpoint.kind,"model":provider.endpoint.model,"base_url":provider.endpoint.base_url,"window_us":WINDOW_US,"timestamp_protocol":"seconds/1"})
+    json!({"kind":provider.endpoint.kind,"model":provider.endpoint.model,"base_url":provider.endpoint.base_url,"window_us":WINDOW_US,"timestamp_protocol":if provider.endpoint.kind == "gemini" && provider.endpoint.model.starts_with("gemini-3.5-transcribe") {"native-word-phrases/1"} else {"seconds/1"}})
 }
 fn transcript_key(episode: &Episode, stream: &str, provider: &Provider) -> Result<String> {
     // Short audio windows avoid long-context timestamp drift and keep inline
@@ -398,10 +398,12 @@ pub async fn transcript(
                         })
                         .map_err(|error| {
                             let message = format!(
-                                "speech transcription window {} ({}-{}s): {error}",
+                                "speech transcription window {} ({}-{}s), model {} at {}: {error}",
                                 index + 1,
                                 media::seconds(window.start_us),
-                                media::seconds(window.end_us)
+                                media::seconds(window.end_us),
+                                provider.endpoint.model,
+                                provider.endpoint.base_url
                             );
                             if let Some(provider_error) =
                                 error.downcast_ref::<crate::providers::ProviderError>()
@@ -548,6 +550,7 @@ mod tests {
                 (200, response),
             ]);
             let mut endpoint = crate::config::Config::default().transcription;
+            endpoint.model = "gemini-3.8-flash".into();
             endpoint.base_url = base;
             let provider = Provider::new(
                 endpoint,
@@ -632,6 +635,7 @@ mod tests {
         responses.extend((0..10).map(|_| reply(segment.clone())));
         let (base, server) = crate::providers::tests::server(responses);
         let mut endpoint = crate::config::Config::default().transcription;
+        endpoint.model = "gemini-3.8-flash".into();
         endpoint.base_url = base;
         let provider = Provider::new(
             endpoint,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod credentials;
 mod documentation_tests;
 mod guide;
 mod render;
+mod setup;
 mod upgrade;
 use anyhow::{Context, Result};
 use cerul::{
@@ -137,6 +138,8 @@ enum Command {
     },
     /// Manage the saved Gemini API key.
     Auth(AuthArgs),
+    /// Configure the required Gemini key and optional default speech transcription.
+    Config,
     /// Generate semantic annotations (tasks, events, states) for videos.
     #[command(
         arg_required_else_help = true,
@@ -738,6 +741,7 @@ enum Outcome {
     /// What the newest release is, and whether this run installed it.
     Upgrade(upgrade::Available, bool),
     Auth(render::KeyState, Option<&'static str>),
+    Configured(bool),
     Remove(
         cerul::clean::Report,
         BTreeMap<String, PathBuf>,
@@ -757,6 +761,7 @@ enum Outcome {
 impl Outcome {
     fn json(&self) -> Result<Value> {
         Ok(match self {
+            Outcome::Configured(saved) => json!({"configured":saved}),
             Outcome::Home(status, _) | Outcome::Status { status, .. } => {
                 serde_json::to_value(status)?
             }
@@ -816,6 +821,11 @@ impl Outcome {
                     &report.targets,
                 ),
             },
+            Outcome::Configured(saved) => writeln!(
+                out,
+                "Configuration {}.",
+                if *saved { "saved" } else { "unchanged" }
+            ),
             Outcome::Auth(key, action) => {
                 match action {
                     Some("set") => {
@@ -1222,6 +1232,11 @@ async fn execute(
                 0,
             ))
         }
+        Some(Command::Config) => {
+            anyhow::ensure!(!cli.json && !cli.quiet && !cli.yes && !cli.dry_run, CliError(2, "cerul config requires an interactive terminal; edit ~/.cerul/config.toml for scripted configuration".into()));
+            let saved = setup::configure(&config(cli)?, cancel).await?;
+            Ok((Outcome::Configured(saved), 0))
+        }
         Some(Command::Auth(args)) => {
             let config = config(cli).map_err(|e| category(2, e))?;
             let endpoint = &config.embedding;
@@ -1516,7 +1531,36 @@ async fn execute(
             ))
         }
         Some(Command::Index(args)) => {
-            let config = config(cli).map_err(|e| category(2, e))?;
+            let mut resolved = config(cli).map_err(|e| category(2, e))?;
+            if !cli.dry_run
+                && !cli.json
+                && !cli.quiet
+                && !cli.yes
+                && guide::asks(&[])
+                && !args.no_audio
+                && resolved.transcription.enabled != Some(false)
+                && (resolved.transcription.enabled.is_none()
+                    || !setup::available(&resolved.transcription))
+                && pipeline::pending_transcription(
+                    &args.paths,
+                    &workspace,
+                    &resolved,
+                    &pipeline::Options {
+                        streams: args.streams.clone(),
+                        only: args.only.clone(),
+                        sidecar_dir: args.sidecar_dir.clone(),
+                        embedding: embed::Options {
+                            recompute: cli.recompute,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                )?
+            {
+                setup::configure(&resolved, cancel.clone()).await?;
+                resolved = config(cli).map_err(|e| category(2, e))?;
+            }
+            let config = resolved;
             anyhow::ensure!(
                 args.jobs > 0 && args.rpm != Some(0),
                 CliError(2, "jobs and RPM must be positive".into())
@@ -1535,7 +1579,8 @@ async fn execute(
                     &palette,
                     &args.paths,
                     args.no_ocr,
-                    args.no_audio,
+                    args.no_audio || config.transcription.enabled != Some(true),
+                    &config.transcription.model,
                 );
             }
             let events = sink.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1093,7 +1093,7 @@ fn names(workspace: &Path) -> BTreeMap<String, PathBuf> {
         })
         .unwrap_or_default()
 }
-const MEDIA_NOTICE: &str = "Using Gemini (media may be sent, usage billed to your key):";
+const MEDIA_NOTICE: &str = "Using model endpoint (media may be sent, usage billed to your key):";
 
 async fn execute(
     cli: &Cli,

--- a/src/main.rs
+++ b/src/main.rs
@@ -942,7 +942,16 @@ fn config(cli: &Cli) -> Result<Config> {
     let environment: BTreeMap<_, _> = std::env::vars()
         .filter(|(key, _)| key.starts_with("CERUL_"))
         .collect();
-    Config::resolve(&paths, &environment, toml::Value::Table(overlay))
+    let config = Config::resolve(&paths, &environment, toml::Value::Table(overlay))?;
+    let fixed = Config::default().embedding;
+    anyhow::ensure!(
+        config.embedding.kind == fixed.kind
+            && config.embedding.model == fixed.model
+            && config.embedding.base_url.trim_end_matches('/') == fixed.base_url
+            && config.embedding.dims == fixed.dims,
+        "embedding is fixed to Gemini gemini-embedding-2 (1536 dimensions); only its credential setting can be changed"
+    );
+    Ok(config)
 }
 fn models(config: &Config) -> render::ModelSummary {
     render::ModelSummary {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -465,7 +465,7 @@ impl Provider {
         }
         let url = self.route(action)?;
         let loopback = matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "[::1]"));
-        if !loopback && !get {
+        if !get {
             self.resolve_key().await?;
         }
         if self.key_header().is_none() && !loopback && !get {
@@ -635,9 +635,7 @@ impl Provider {
 
     pub async fn transcribe(&self, audio: Vec<u8>, duration_us: i64) -> Result<Value> {
         ensure!(duration_us > 0, "invalid transcription duration");
-        if self.endpoint.kind == "gemini"
-            && self.endpoint.model.starts_with("gemini-3.5-transcribe")
-        {
+        if self.endpoint.uses_native_transcription() {
             let response = self.json("generateContent", json!({
                 "contents": [{"role": "user", "parts": [Input::Audio(audio, "audio/wav".into()).gemini()]}],
                 "generationConfig": {"audioTranscriptionConfig": {"mode": "VERBATIM", "wordTimestamp": true}}
@@ -903,7 +901,7 @@ pub(crate) mod tests {
             ]}}]}),
         )]);
         let mut provider = provider(base, "gemini");
-        provider.endpoint.model = "gemini-3.5-transcribe".into();
+        provider.endpoint.model = "models/gemini-3.5-transcribe".into();
         let result = provider.transcribe(vec![0; 44], 1_000_000).await.unwrap();
         assert_eq!(result["segments"][0]["start_us"], 125000);
         assert_eq!(result["segments"][0]["end_us"], 900000);
@@ -1269,6 +1267,29 @@ pub(crate) mod tests {
 #[cfg(test)]
 mod credential_scope_tests {
     use super::*;
+    #[tokio::test]
+    async fn loopback_requests_resolve_saved_credentials() {
+        let (base, server) = tests::server(vec![(
+            200,
+            serde_json::json!({"embedding":{"values":[1.,0.]}}),
+        )]);
+        let resolver: CredentialResolver =
+            Arc::new(|_| Box::pin(async { Ok(Some("local-fixture-key".into())) }));
+        with_credential_resolver(resolver, async {
+            let mut endpoint = crate::config::Config::default().embedding;
+            endpoint.base_url = base;
+            endpoint.dims = Some(2);
+            let provider =
+                Provider::new(endpoint, None, 1, None, CancellationToken::new()).unwrap();
+            provider
+                .embed(Input::Text("fixture".into()), true)
+                .await
+                .unwrap();
+            assert_eq!(provider.key_header().unwrap(), "local-fixture-key");
+        })
+        .await;
+        assert_eq!(server.join().unwrap().len(), 1);
+    }
     #[tokio::test]
     async fn host_resolution_is_lazy_and_missing_credentials_are_resolved_once() {
         use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -762,9 +762,9 @@ fn native_transcript(response: &Value) -> Result<Value> {
         if let Some(last) = phrases.last_mut() {
             let last_start = last["start_us"].as_i64().unwrap();
             let last_end = last["end_us"].as_i64().unwrap();
-            if start == end
-                || last_start == last_end
-                || (end - last_start <= 5_000_000 && start - last_end <= 750_000)
+            if end.max(last_end) - start.min(last_start) <= 5_000_000
+                && start - last_end <= 750_000
+                && last_start - end <= 750_000
             {
                 last["start_us"] = json!(last_start.min(start));
                 last["end_us"] = json!(last_end.max(end));
@@ -782,7 +782,7 @@ fn native_transcript(response: &Value) -> Result<Value> {
         phrases
             .iter()
             .all(|p| p["end_us"].as_i64() > p["start_us"].as_i64()),
-        "native transcription has no positive-duration speech interval"
+        "native transcription contains an isolated zero-duration token without a nearby timed word"
     );
     Ok(json!({"segments":phrases}))
 }
@@ -878,6 +878,22 @@ pub(crate) mod tests {
         )
         .unwrap()
     }
+    #[test]
+    fn native_point_tokens_do_not_bridge_long_silence() {
+        let response = |words| json!({"candidates":[{"finishReason":"STOP","content":{"parts":[{"audioTranscription":{"words":words}}]}}]});
+        let words = json!([
+            {"word":"hello","startOffset":"0s","endOffset":"1s"},
+            {"word":"!","startOffset":"50s","endOffset":"50s"}
+        ]);
+        assert!(native_transcript(&response(words.clone())).is_err());
+        let mut words = words.as_array().unwrap().clone();
+        words.push(json!({"word":"next","startOffset":"50.1s","endOffset":"51s"}));
+        let result = native_transcript(&response(json!(words))).unwrap();
+        assert_eq!(result["segments"].as_array().unwrap().len(), 2);
+        assert_eq!(result["segments"][0]["end_us"], 1_000_000);
+        assert_eq!(result["segments"][1]["start_us"], 50_000_000);
+    }
+
     #[tokio::test]
     async fn native_asr_preserves_word_offsets_and_does_not_request_json_generation() {
         let (base, server) = server(vec![(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -928,6 +928,12 @@ pub(crate) mod tests {
             ),
         ];
         let mut cases = cases;
+        cases.push((
+            json!({"candidates":[{"finishReason":"OTHER","content":{"parts":[{"text":"{}"}]}}]}),
+            "gemini",
+            Failure::InvalidResponse,
+            "finishReason=OTHER",
+        ));
         for reason in [
             "LANGUAGE",
             "IMAGE_SAFETY",

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -635,6 +635,15 @@ impl Provider {
 
     pub async fn transcribe(&self, audio: Vec<u8>, duration_us: i64) -> Result<Value> {
         ensure!(duration_us > 0, "invalid transcription duration");
+        if self.endpoint.kind == "gemini"
+            && self.endpoint.model.starts_with("gemini-3.5-transcribe")
+        {
+            let response = self.json("generateContent", json!({
+                "contents": [{"role": "user", "parts": [Input::Audio(audio, "audio/wav".into()).gemini()]}],
+                "generationConfig": {"audioTranscriptionConfig": {"mode": "VERBATIM", "wordTimestamp": true}}
+            })).await?;
+            return native_transcript(&response);
+        }
         let response = if self.endpoint.kind == "gemini" {
             let prompt = format!(
                 "Transcribe this {}-second audio clip accurately. Return chronological speech segments with start and end measured in seconds from the beginning of THIS clip. Include silence in the timeline; do not reset time at speech or pauses. Every segment must have end greater than start. If there is no speech, return an empty segments array, not a placeholder segment. Keep spoken text in its original language; lang is an ISO language code. Do not invent speech in silence.",
@@ -690,6 +699,92 @@ impl Provider {
         }
         Ok(json!({"segments":normalized}))
     }
+}
+
+/// Normalize Gemini's native word annotations without asking a language model to invent JSON.
+fn native_transcript(response: &Value) -> Result<Value> {
+    let text = structured_text(response, true)?;
+    let parts = match response["candidates"][0]["content"]["parts"].as_array() {
+        Some(parts) => parts,
+        None if response["candidates"][0]["finishReason"] == "STOP" && text.trim().is_empty() => {
+            return Ok(json!({"segments":[]}));
+        }
+        None => {
+            return Err(failure(
+                Failure::InvalidResponse,
+                "Gemini transcription returned no parts",
+            ));
+        }
+    };
+    let mut segments = Vec::new();
+    for part in parts {
+        if part["thought"] == true {
+            continue;
+        }
+        if let Some(words) = part["audioTranscription"]["words"].as_array() {
+            for word in words {
+                let offset = |field: &str| -> Result<i64> {
+                    let raw = word[field]
+                        .as_str()
+                        .and_then(|s| s.strip_suffix('s'))
+                        .context("invalid native transcription offset")?;
+                    let value: f64 = raw.parse().context("invalid native transcription offset")?;
+                    ensure!(
+                        value.is_finite() && (0. ..1e12).contains(&value),
+                        "invalid native transcription offset"
+                    );
+                    Ok((value * 1_000_000.).round() as i64)
+                };
+                let word_text = word["word"]
+                    .as_str()
+                    .context("native transcription word missing text")?;
+                segments.push(json!({"start_us":offset("startOffset")?, "end_us":offset("endOffset")?, "text":word_text, "lang":null}));
+            }
+        }
+    }
+    ensure!(
+        !segments.is_empty() || text.trim().is_empty(),
+        failure(
+            Failure::Unsupported,
+            "transcription endpoint returned text without word timestamps"
+        )
+    );
+    // Native recognizers can attach punctuation or short words to an instant.
+    // Keep those tokens in a neighboring timed phrase instead of fabricating a duration.
+    let mut phrases: Vec<Value> = Vec::new();
+    for segment in segments {
+        let start = segment["start_us"].as_i64().unwrap();
+        let end = segment["end_us"].as_i64().unwrap();
+        ensure!(
+            end >= start,
+            "native transcription has reversed word timestamps"
+        );
+        if let Some(last) = phrases.last_mut() {
+            let last_start = last["start_us"].as_i64().unwrap();
+            let last_end = last["end_us"].as_i64().unwrap();
+            if start == end
+                || last_start == last_end
+                || (end - last_start <= 5_000_000 && start - last_end <= 750_000)
+            {
+                last["start_us"] = json!(last_start.min(start));
+                last["end_us"] = json!(last_end.max(end));
+                last["text"] = json!(format!(
+                    "{} {}",
+                    last["text"].as_str().unwrap(),
+                    segment["text"].as_str().unwrap()
+                ));
+                continue;
+            }
+        }
+        phrases.push(segment);
+    }
+    ensure!(
+        phrases
+            .iter()
+            .all(|p| p["end_us"].as_i64() > p["start_us"].as_i64()),
+        "native transcription has no positive-duration speech interval"
+    );
+    Ok(json!({"segments":phrases}))
 }
 
 #[cfg(test)]
@@ -774,6 +869,7 @@ pub(crate) mod tests {
                 base_url: base,
                 api_key_env: "TEST_KEY".into(),
                 dims: Some(2),
+                enabled: None,
             },
             None,
             2,
@@ -782,6 +878,51 @@ pub(crate) mod tests {
         )
         .unwrap()
     }
+    #[tokio::test]
+    async fn native_asr_preserves_word_offsets_and_does_not_request_json_generation() {
+        let (base, server) = server(vec![(
+            200,
+            json!({"candidates":[{"finishReason":"STOP","content":{"parts":[
+                {"text":"hello", "audioTranscription":{"words":[{"word":"hello","startOffset":"0.125s","endOffset":"0.900s"}]}}
+            ]}}]}),
+        )]);
+        let mut provider = provider(base, "gemini");
+        provider.endpoint.model = "gemini-3.5-transcribe".into();
+        let result = provider.transcribe(vec![0; 44], 1_000_000).await.unwrap();
+        assert_eq!(result["segments"][0]["start_us"], 125000);
+        assert_eq!(result["segments"][0]["end_us"], 900000);
+        let joined = native_transcript(&json!({"candidates":[{"finishReason":"STOP","content":{"parts":[{"audioTranscription":{"words":[
+            {"word":"hello","startOffset":"0.1s","endOffset":"0.8s"},
+            {"word":"!","startOffset":"0.8s","endOffset":"0.8s"}
+        ]}}]}}]})).unwrap();
+        assert_eq!(joined["segments"][0]["text"], "hello !");
+        assert_eq!(joined["segments"].as_array().unwrap().len(), 1);
+        let requests = server.join().unwrap();
+        assert_eq!(
+            requests[0].1["generationConfig"]["audioTranscriptionConfig"]["wordTimestamp"],
+            true
+        );
+        assert!(
+            requests[0].1["generationConfig"]
+                .get("responseJsonSchema")
+                .is_none()
+        );
+        assert_eq!(
+            native_transcript(&json!({"candidates":[{"finishReason":"STOP"}]})).unwrap()["segments"],
+            json!([])
+        );
+        assert!(native_transcript(&json!({})).is_err());
+        assert!(native_transcript(&json!({"candidates":[{"finishReason":"STOP","content":{"parts":[{"text":"missing timestamps"}]}}]})).is_err());
+        assert!(native_transcript(&json!({"promptFeedback":{"blockReason":"OTHER"}})).is_err());
+        assert_eq!(
+            native_transcript(
+                &json!({"candidates":[{"finishReason":"STOP","content":{"parts":[{"text":""}]}}]})
+            )
+            .unwrap()["segments"],
+            json!([])
+        );
+    }
+
     #[tokio::test]
     async fn gemini_json_retry_hint_is_observed_and_default_backoff_is_cancellable() {
         let (base, server) = server_with_retry_header(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -110,7 +110,10 @@ fn response_reason(value: &Value) -> &str {
         | "NO_IMAGE"
         | "IMAGE_RECITATION"
         | "MISSING_THOUGHT_SIGNATURE"
-        | "ESCALATION") => reason,
+        | "ESCALATION"
+        | "MODEL_ARMOR"
+        | "JAILBREAK"
+        | "BLOCKED_REASON_UNSPECIFIED") => reason,
         _ => "UNKNOWN",
     }
 }
@@ -118,7 +121,10 @@ fn response_reason(value: &Value) -> &str {
 fn structured_text(response: &Value, gemini: bool) -> Result<String> {
     if gemini {
         let blocked = &response["promptFeedback"]["blockReason"];
-        if blocked.is_string() && blocked != "BLOCK_REASON_UNSPECIFIED" {
+        if blocked.is_string()
+            && blocked != "BLOCK_REASON_UNSPECIFIED"
+            && blocked != "BLOCKED_REASON_UNSPECIFIED"
+        {
             return Err(failure(
                 Failure::Rejected,
                 format!(
@@ -139,6 +145,7 @@ fn structured_text(response: &Value, gemini: bool) -> Result<String> {
                     | "PROHIBITED_CONTENT"
                     | "SPII"
                     | "ESCALATION"
+                    | "MODEL_ARMOR"
                     | "LANGUAGE"
                     | "IMAGE_SAFETY"
                     | "IMAGE_PROHIBITED_CONTENT"
@@ -934,7 +941,20 @@ pub(crate) mod tests {
             Failure::InvalidResponse,
             "finishReason=OTHER",
         ));
+        cases.push((
+            json!({"promptFeedback":{"blockReason":"MODEL_ARMOR"}}),
+            "gemini",
+            Failure::Rejected,
+            "blockReason=MODEL_ARMOR",
+        ));
+        cases.push((
+            json!({"promptFeedback":{"blockReason":"JAILBREAK"}}),
+            "gemini",
+            Failure::Rejected,
+            "blockReason=JAILBREAK",
+        ));
         for reason in [
+            "MODEL_ARMOR",
             "LANGUAGE",
             "IMAGE_SAFETY",
             "IMAGE_PROHIBITED_CONTENT",
@@ -971,7 +991,7 @@ pub(crate) mod tests {
     async fn gemini_structured_output_joins_text_and_ignores_thoughts() {
         let (base, server) = server(vec![(
             200,
-            json!({"candidates":[{"finishReason":"STOP","content":{"parts":[
+            json!({"promptFeedback":{"blockReason":"BLOCKED_REASON_UNSPECIFIED"},"candidates":[{"finishReason":"STOP","content":{"parts":[
                 {"thought":true,"text":"not JSON"}, {"text":"{\"ok\":"}, {"text":"true}"}
             ]}}]}),
         )]);

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -85,6 +85,107 @@ fn failure(kind: Failure, message: impl Into<String>) -> anyhow::Error {
     .into()
 }
 
+// Only known protocol codes are safe to expose; free-form provider fields can
+// contain credentials or user media. Never include response text in errors.
+fn response_reason(value: &Value) -> &str {
+    match value.as_str().unwrap_or("UNKNOWN") {
+        reason @ ("STOP"
+        | "MAX_TOKENS"
+        | "SAFETY"
+        | "RECITATION"
+        | "OTHER"
+        | "BLOCKLIST"
+        | "PROHIBITED_CONTENT"
+        | "SPII"
+        | "LANGUAGE"
+        | "MALFORMED_RESPONSE"
+        | "MALFORMED_FUNCTION_CALL"
+        | "UNEXPECTED_TOOL_CALL"
+        | "TOO_MANY_TOOL_CALLS"
+        | "FINISH_REASON_UNSPECIFIED"
+        | "BLOCK_REASON_UNSPECIFIED"
+        | "IMAGE_SAFETY"
+        | "IMAGE_PROHIBITED_CONTENT"
+        | "IMAGE_OTHER"
+        | "NO_IMAGE"
+        | "IMAGE_RECITATION"
+        | "MISSING_THOUGHT_SIGNATURE"
+        | "ESCALATION") => reason,
+        _ => "UNKNOWN",
+    }
+}
+
+fn structured_text(response: &Value, gemini: bool) -> Result<String> {
+    if gemini {
+        let blocked = &response["promptFeedback"]["blockReason"];
+        if blocked.is_string() && blocked != "BLOCK_REASON_UNSPECIFIED" {
+            return Err(failure(
+                Failure::Rejected,
+                format!(
+                    "Gemini blocked the request (promptFeedback.blockReason={}); no structured output was generated",
+                    response_reason(blocked)
+                ),
+            ));
+        }
+        let candidate = &response["candidates"][0];
+        let reason = &candidate["finishReason"];
+        if reason.is_string() && reason != "STOP" {
+            let code = response_reason(reason);
+            let kind = if matches!(
+                code,
+                "SAFETY"
+                    | "RECITATION"
+                    | "BLOCKLIST"
+                    | "PROHIBITED_CONTENT"
+                    | "SPII"
+                    | "ESCALATION"
+            ) {
+                Failure::Rejected
+            } else {
+                Failure::InvalidResponse
+            };
+            return Err(failure(
+                kind,
+                format!("Gemini did not complete structured output (finishReason={code})"),
+            ));
+        }
+        Ok(candidate["content"]["parts"]
+            .as_array()
+            .map(|parts| {
+                parts
+                    .iter()
+                    .filter(|p| p["thought"] != true)
+                    .filter_map(|p| p["text"].as_str())
+                    .collect::<String>()
+            })
+            .unwrap_or_default())
+    } else {
+        let choice = &response["choices"][0];
+        if choice["message"]["refusal"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty())
+        {
+            return Err(failure(
+                Failure::Rejected,
+                "model refused the structured output request",
+            ));
+        }
+        if choice["finish_reason"] == "length" {
+            return Err(failure(
+                Failure::InvalidResponse,
+                "model structured output was truncated (finish_reason=length)",
+            ));
+        }
+        if choice["finish_reason"] == "content_filter" {
+            return Err(failure(
+                Failure::Rejected,
+                "model blocked structured output (finish_reason=content_filter)",
+            ));
+        }
+        Ok(choice["message"]["content"].as_str().unwrap_or("").into())
+    }
+}
+
 #[derive(Clone)]
 pub struct Provider {
     pub endpoint: Endpoint,
@@ -506,30 +607,21 @@ impl Provider {
             content.extend(inputs.iter().map(Input::openai));
             self.json("chat/completions",json!({"model":self.endpoint.model,"messages":[{"role":"user","content":content}],"response_format":{"type":"json_schema","json_schema":{"name":"cerul_output","strict":true,"schema":schema}}})).await?
         };
-        let text = if self.endpoint.kind == "gemini" {
-            response["candidates"][0]["content"]["parts"]
-                .as_array()
-                .map(|parts| {
-                    parts
-                        .iter()
-                        .filter(|p| p["thought"] != true)
-                        .filter_map(|p| p["text"].as_str())
-                        .collect::<String>()
-                })
-                .unwrap_or_default()
-        } else {
-            response["choices"][0]["message"]["content"]
-                .as_str()
-                .unwrap_or("")
-                .into()
-        };
-        serde_json::from_str(&text).map_err(|_| {
-            failure(
+        let text = structured_text(&response, self.endpoint.kind == "gemini")?;
+        if text.trim().is_empty() {
+            return Err(failure(
                 Failure::InvalidResponse,
-                "model returned no structured output",
-            )
+                "model returned empty structured output (no non-thought text)",
+            ));
+        }
+        serde_json::from_str(&text).map_err(|error| {
+            failure(Failure::InvalidResponse, format!(
+                "model returned invalid structured JSON ({} bytes, category={:?}, line={}, column={})",
+                text.len(), error.classify(), error.line(), error.column()
+            ))
         })
     }
+
     pub async fn transcribe(&self, audio: Vec<u8>, duration_us: i64) -> Result<Value> {
         ensure!(duration_us > 0, "invalid transcription duration");
         let response = if self.endpoint.kind == "gemini" {
@@ -767,6 +859,114 @@ pub(crate) mod tests {
                 .contains("query: query")
         );
     }
+    #[tokio::test]
+    async fn structured_response_failures_preserve_reason_without_exposing_payloads() {
+        let cases = vec![
+            (
+                json!({"promptFeedback":{"blockReason":"OTHER","blockReasonMessage":"private payload"}}),
+                "gemini",
+                Failure::Rejected,
+                "blockReason=OTHER",
+            ),
+            (
+                json!({"promptFeedback":{"blockReason":"private payload"}}),
+                "gemini",
+                Failure::Rejected,
+                "blockReason=UNKNOWN",
+            ),
+            (
+                json!({"candidates":[{"finishReason":"MAX_TOKENS","content":{"parts":[{"text":"{}"}]}}]}),
+                "gemini",
+                Failure::InvalidResponse,
+                "finishReason=MAX_TOKENS",
+            ),
+            (
+                json!({"candidates":[{"finishReason":"SAFETY"}]}),
+                "gemini",
+                Failure::Rejected,
+                "finishReason=SAFETY",
+            ),
+            (
+                json!({"candidates":[]}),
+                "gemini",
+                Failure::InvalidResponse,
+                "empty structured output",
+            ),
+            (
+                json!({"candidates":[{"finishReason":"STOP","content":{"parts":[{"thought":true,"text":"private payload"}]}}]}),
+                "gemini",
+                Failure::InvalidResponse,
+                "empty structured output",
+            ),
+            (
+                json!({"candidates":[{"finishReason":"STOP","content":{"parts":[{"text":"private payload"}]}}]}),
+                "gemini",
+                Failure::InvalidResponse,
+                "invalid structured JSON",
+            ),
+            (
+                json!({"choices":[{"message":{"refusal":"private payload"}}]}),
+                "openai",
+                Failure::Rejected,
+                "refused",
+            ),
+            (
+                json!({"choices":[{"finish_reason":"length","message":{"content":"{}"}}]}),
+                "openai",
+                Failure::InvalidResponse,
+                "truncated",
+            ),
+            (
+                json!({"choices":[{"finish_reason":"content_filter"}]}),
+                "openai",
+                Failure::Rejected,
+                "content_filter",
+            ),
+        ];
+        for (body, kind, expected, detail) in cases {
+            let (base, server) = server(vec![(200, body)]);
+            let error = provider(base, kind)
+                .generate("check", &[], json!({"type":"object"}))
+                .await
+                .unwrap_err();
+            assert_eq!(
+                error.downcast_ref::<ProviderError>().unwrap().kind,
+                expected
+            );
+            assert!(error.to_string().contains(detail), "{error}");
+            assert!(!error.to_string().contains("private payload"));
+            assert_eq!(
+                server.join().unwrap().len(),
+                1,
+                "response failures must not be retried"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn gemini_structured_output_joins_text_and_ignores_thoughts() {
+        let (base, server) = server(vec![(
+            200,
+            json!({"candidates":[{"finishReason":"STOP","content":{"parts":[
+                {"thought":true,"text":"not JSON"}, {"text":"{\"ok\":"}, {"text":"true}"}
+            ]}}]}),
+        )]);
+        let schema =
+            json!({"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"]});
+        assert_eq!(
+            provider(base, "gemini")
+                .generate("check", &[], schema.clone())
+                .await
+                .unwrap(),
+            json!({"ok":true})
+        );
+        let requests = server.join().unwrap();
+        assert_eq!(
+            requests[0].1["generationConfig"]["responseJsonSchema"],
+            schema
+        );
+    }
+
     #[tokio::test]
     async fn openai_vision_and_transcription_use_distinct_wire_contracts() {
         let (base, server) = server(vec![

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -139,6 +139,10 @@ fn structured_text(response: &Value, gemini: bool) -> Result<String> {
                     | "PROHIBITED_CONTENT"
                     | "SPII"
                     | "ESCALATION"
+                    | "LANGUAGE"
+                    | "IMAGE_SAFETY"
+                    | "IMAGE_PROHIBITED_CONTENT"
+                    | "IMAGE_RECITATION"
             ) {
                 Failure::Rejected
             } else {
@@ -923,6 +927,20 @@ pub(crate) mod tests {
                 "content_filter",
             ),
         ];
+        let mut cases = cases;
+        for reason in [
+            "LANGUAGE",
+            "IMAGE_SAFETY",
+            "IMAGE_PROHIBITED_CONTENT",
+            "IMAGE_RECITATION",
+        ] {
+            cases.push((
+                json!({"candidates":[{"finishReason":reason}]}),
+                "gemini",
+                Failure::Rejected,
+                reason,
+            ));
+        }
         for (body, kind, expected, detail) in cases {
             let (base, server) = server(vec![(200, body)]);
             let error = provider(base, kind)

--- a/src/render.rs
+++ b/src/render.rs
@@ -955,11 +955,11 @@ pub fn status(
         .episodes
         .iter()
         .flat_map(|episode| &episode.embeddings)
-        .find(|state| !state.complete && state.error.is_some())
+        .find(|state| state.error.is_some())
     {
         writeln!(
             out,
-            "  {} search index incomplete: {}",
+            "  {} processing issue: {}",
             palette.warn("!"),
             failed.error.as_deref().unwrap_or_default()
         )?;
@@ -1276,6 +1276,7 @@ pub fn index_plan(
     paths: &[PathBuf],
     no_ocr: bool,
     no_audio: bool,
+    speech_model: &str,
 ) -> io::Result<()> {
     let names: Vec<String> = paths.iter().map(|path| file_name(path)).collect();
     writeln!(
@@ -1289,7 +1290,10 @@ pub fn index_plan(
         stations.push(format!("screen text {}", palette.dim("(local)")));
     }
     if !no_audio {
-        stations.push(format!("speech {}", palette.dim("(Gemini)")));
+        stations.push(format!(
+            "speech {}",
+            palette.dim(&format!("({speech_model})"))
+        ));
     }
     stations.push(format!("search index {}", palette.dim("(Gemini)")));
     writeln!(out, "  {}", stations.join(&palette.dim("  ·  ")))?;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,0 +1,173 @@
+//! Human configuration lives in the binary; processing stays non-interactive.
+use anyhow::{Context, Result, ensure};
+use cerul::config::{Config, Endpoint};
+use std::{fs, io::Write, path::PathBuf};
+use tokio_util::sync::CancellationToken;
+
+fn path() -> Result<PathBuf> {
+    Ok(
+        PathBuf::from(std::env::var_os("HOME").context("HOME is required to save configuration")?)
+            .join(".cerul/config.toml"),
+    )
+}
+
+pub fn available(endpoint: &Endpoint) -> bool {
+    let state = crate::credentials::state(endpoint);
+    state.env_set || state.saved
+}
+
+fn preset(name: &str) -> Endpoint {
+    let mut endpoint = Config::default().transcription;
+    endpoint.enabled = Some(true);
+    match name {
+        "openai" => {
+            endpoint.kind = "openai".into();
+            endpoint.base_url = "https://api.openai.com/v1".into();
+            endpoint.api_key_env = "OPENAI_API_KEY".into();
+            endpoint.model = "whisper-1".into();
+        }
+        "groq" => {
+            endpoint.kind = "openai".into();
+            endpoint.base_url = "https://api.groq.com/openai/v1".into();
+            endpoint.api_key_env = "GROQ_API_KEY".into();
+            endpoint.model = "whisper-large-v3-turbo".into();
+        }
+        "custom" => {
+            endpoint.kind = "openai".into();
+            endpoint.api_key_env = "ASR_API_KEY".into();
+            endpoint.model.clear();
+            endpoint.base_url.clear();
+        }
+        _ => {}
+    }
+    endpoint
+}
+
+fn field(label: &str, default: &str) -> Result<String> {
+    let term = console::Term::stderr();
+    term.write_str(&format!("{label} [{}]: ", default))?;
+    let value = term.read_line()?;
+    let value = value.trim();
+    Ok(if value.is_empty() {
+        default.into()
+    } else {
+        value.into()
+    })
+}
+
+fn save(endpoint: &Endpoint) -> Result<()> {
+    let path = path()?;
+    let mut document: toml::Table = match fs::read_to_string(&path) {
+        Ok(text) => toml::from_str(&text)?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => toml::Table::new(),
+        Err(e) => return Err(e.into()),
+    };
+    document.insert("transcription".into(), toml::Value::try_from(endpoint)?);
+    let parent = path.parent().unwrap();
+    fs::create_dir_all(parent)?;
+    let mut file = tempfile::NamedTempFile::new_in(parent)?;
+    file.write_all(toml::to_string_pretty(&document)?.as_bytes())?;
+    file.as_file().sync_all()?;
+    file.persist(&path).map_err(|e| e.error)?;
+    Ok(())
+}
+
+pub async fn configure(config: &Config, cancel: CancellationToken) -> Result<bool> {
+    ensure!(
+        crate::guide::asks(&[]),
+        "cerul config requires an interactive terminal; edit ~/.cerul/config.toml for scripted configuration"
+    );
+    if !available(&config.embedding) {
+        crate::credentials::set(&config.embedding, cancel.clone()).await?;
+    }
+    eprintln!("Embedding: Gemini gemini-embedding-2 (1536 dimensions)");
+    let palette = crate::render::Palette::new(console::colors_enabled_stderr());
+    use crate::guide::Choice;
+    let selection = crate::guide::select(
+        &palette,
+        "Speech transcription",
+        &[
+            Choice::new("Gemini", "Reuse the Gemini key", "gemini"),
+            Choice::new("Groq", "Whisper transcription", "groq"),
+            Choice::new("OpenAI", "Whisper transcription", "openai"),
+            Choice::new("Custom", "OpenAI-compatible transcription API", "custom"),
+            Choice::new(
+                "Disabled",
+                "Index video without a separate transcript",
+                "disabled",
+            ),
+        ],
+    )?;
+    let Some(selection) = selection else {
+        return Ok(false);
+    };
+    let mut endpoint = preset(selection);
+    if selection == "disabled" {
+        endpoint.enabled = Some(false);
+    } else {
+        if selection == "custom" {
+            endpoint.base_url = field("Base URL (for example https://host/v1)", "")?;
+        }
+        endpoint.model = field("ASR model", &endpoint.model)?;
+        let mut candidate = config.clone();
+        candidate.transcription = endpoint.clone();
+        candidate.validate()?;
+        let key_state = crate::credentials::state(&endpoint);
+        if key_state.env_set {
+            eprintln!(
+                "Using {} from the environment; change that variable to replace it.",
+                endpoint.api_key_env
+            );
+        } else if key_state.saved {
+            let keep = crate::guide::select(
+                &palette,
+                "ASR credential",
+                &[
+                    Choice::new("Use saved key", "", true),
+                    Choice::new("Replace saved key", "Enter a new hidden key", false),
+                ],
+            )?;
+            match keep {
+                Some(false) => crate::credentials::set(&endpoint, cancel.clone()).await?,
+                Some(true) => {}
+                None => return Ok(false),
+            }
+        } else {
+            crate::credentials::set(&endpoint, cancel.clone()).await?;
+        }
+        // Even a shared or environment key must be checked against the selected ASR model.
+        let provider = cerul::providers::Provider::from_env(endpoint.clone(), 1, None, cancel)?;
+        let temporary = tempfile::tempdir()?;
+        cerul::providers::probes::check(
+            &provider,
+            cerul::providers::probes::Capability::Transcription,
+            temporary.path(),
+            true,
+        )
+        .await?;
+        eprintln!("ASR connection and timestamp response verified (silent test clip).");
+    }
+    save(&endpoint)?;
+    eprintln!("Saved defaults. Run cerul config to change them.");
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn presets_share_protocol_not_credentials() {
+        let groq = preset("groq");
+        let openai = preset("openai");
+        assert_eq!(groq.kind, openai.kind);
+        assert_ne!(
+            cerul::providers::credential_scope(&groq),
+            cerul::providers::credential_scope(&openai)
+        );
+        assert_eq!(
+            preset("gemini").api_key_env,
+            Config::default().embedding.api_key_env
+        );
+        assert_eq!(preset("custom").api_key_env, "ASR_API_KEY");
+    }
+}

--- a/src/status.rs
+++ b/src/status.rs
@@ -495,17 +495,20 @@ pub async fn check_providers(
         base_url: config.perception.base_url.clone(),
         api_key_env: config.perception.api_key_env.clone(),
         dims: None,
+        enabled: None,
     };
     let mut partial = false;
     let mut endpoints = vec![
         ("embedding", &config.embedding, Capability::Embedding),
         ("vision", &config.vision, Capability::Vision),
-        (
+    ];
+    if config.transcription.enabled == Some(true) {
+        endpoints.push((
             "transcription",
             &config.transcription,
             Capability::Transcription,
-        ),
-    ];
+        ));
+    }
     if perception_configured(config) {
         endpoints.push(("perception", &perception, Capability::Perception));
     }
@@ -586,6 +589,8 @@ mod tests {
         config.embedding.dims = Some(2);
         config.vision.base_url = base.clone();
         config.transcription.base_url = base.clone();
+        config.transcription.enabled = Some(true);
+        config.transcription.model = "gemini-3.8-flash".into();
         config.perception.base_url = base;
         let cancel = tokio_util::sync::CancellationToken::new();
         let mut status = inspect(dir.path(), None).unwrap();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -59,53 +59,22 @@ fn json_argument_errors_and_dry_run_are_machine_readable_and_do_not_write() {
     assert!(dry.stderr.is_empty());
 }
 #[test]
-fn offline_index_exits_partial_with_ndjson_events_and_endpoint_notice_once() {
+fn unsupported_embedding_configuration_is_rejected_before_processing() {
     let dir = tempfile::tempdir().unwrap();
     video(dir.path());
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-    let endpoint = format!(
-        "embedding.base_url=\"http://{}/\"",
-        listener.local_addr().unwrap()
-    );
-    drop(listener);
-    let output = cli(
-        dir.path(),
-        &[
-            "--json",
-            "index",
-            "sample.mp4",
-            "--no-audio",
-            "--no-ocr",
-            "--set",
-            &endpoint,
-        ],
-    );
-    assert_eq!(
-        output.status.code(),
-        Some(6),
-        "{}",
-        String::from_utf8_lossy(&output.stdout)
-    );
-    assert_eq!(final_json(&output)["partial"], true);
-    let events: Vec<Value> = std::str::from_utf8(&output.stderr)
-        .unwrap()
-        .lines()
-        .map(|line| serde_json::from_str(line).unwrap())
-        .collect();
-    assert_eq!(
-        events
-            .iter()
-            .filter(|e| e["msg"]
-                .as_str()
-                .is_some_and(|s| s.starts_with("Using Gemini")))
-            .count(),
-        1
-    );
-    let status = cli(dir.path(), &["--json", "status"]);
-    assert!(status.status.success());
-    let value = final_json(&status);
-    assert_eq!(value["episodes"][0]["embeddings"][0]["complete"], false);
-    assert!(status.stderr.is_empty());
+    for setting in [
+        "embedding.model=\"other\"",
+        "embedding.kind=\"openai\"",
+        "embedding.base_url=\"http://127.0.0.1:9/v1\"",
+        "embedding.dims=768",
+    ] {
+        let output = cli(
+            dir.path(),
+            &["--json", "index", "sample.mp4", "--set", setting],
+        );
+        assert_eq!(output.status.code(), Some(2), "{output:?}");
+        assert!(!dir.path().join("sample.mp4.cerul").exists());
+    }
 }
 
 #[test]
@@ -459,14 +428,14 @@ fn offline_commands_ignore_unusable_saved_credentials() {
 }
 
 #[test]
-fn missing_key_keeps_local_processing_and_environment_bypasses_corrupt_saved_keys() {
+fn missing_embedding_key_and_unsupported_endpoint_fail_before_processing() {
     let dir = tempfile::tempdir().unwrap();
     video(dir.path());
     let output = cli(
         dir.path(),
         &["--json", "index", "sample.mp4", "--no-audio", "--no-ocr"],
     );
-    assert_eq!(output.status.code(), Some(6), "{:?}", output);
+    assert_eq!(output.status.code(), Some(2), "{:?}", output);
     std::fs::create_dir_all(dir.path().join(".cerul")).unwrap();
     std::fs::write(dir.path().join(".cerul/credentials.json"), "invalid").unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_cerul"))
@@ -486,7 +455,7 @@ fn missing_key_keeps_local_processing_and_environment_bypasses_corrupt_saved_key
         ])
         .output()
         .unwrap();
-    assert_eq!(output.status.code(), Some(6), "{:?}", output);
+    assert_eq!(output.status.code(), Some(2), "{:?}", output);
     assert!(!String::from_utf8_lossy(&output.stdout).contains("credential file"));
 }
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,121 @@
+"""Opt-in PTY integration checks: CERUL_TEST_BINARY=/path/to/cerul python3 -m unittest discover -s tests -p test_setup.py."""
+import http.server
+import json
+import os
+import pathlib
+import pty
+import select
+import signal
+import tempfile
+import threading
+import termios
+import time
+import unittest
+
+
+@unittest.skipUnless(os.environ.get("CERUL_TEST_BINARY"), "requires a built CLI")
+class SetupTests(unittest.TestCase):
+    def interact(self, home, steps, parent_ready=None):
+        pid, fd = pty.fork()
+        if pid == 0:
+            env = {"HOME": str(home), "PATH": os.environ["PATH"], "TERM": "xterm", "GEMINI_API_KEY": "fixture-embedding-key"}
+            os.execve(os.environ["CERUL_TEST_BINARY"], ["cerul", "config"], env)
+        if parent_ready:
+            parent_ready()
+        output = b""
+        pending = list(steps)
+        eof = False
+        try:
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                if select.select([fd], [], [], 0.1)[0]:
+                    try:
+                        chunk = os.read(fd, 65536)
+                    except OSError:
+                        eof = True
+                        break
+                    if not chunk:
+                        eof = True
+                        break
+                    output += chunk
+                    if pending and pending[0][0] in output:
+                        prompt, answer = pending.pop(0)
+                        if b"hidden" in prompt:
+                            until = time.monotonic() + 2
+                            while termios.tcgetattr(fd)[3] & termios.ECHO and time.monotonic() < until:
+                                time.sleep(0.01)
+                        os.write(fd, answer)
+                child, status = os.waitpid(pid, os.WNOHANG)
+                if child:
+                    self.assertEqual(os.waitstatus_to_exitcode(status), 0, output.decode(errors="replace"))
+                    pid = None
+                    break
+            if pid:
+                child, status = os.waitpid(pid, 0 if eof else os.WNOHANG)
+                if child:
+                    pid = None
+                    self.assertEqual(os.waitstatus_to_exitcode(status), 0, output.decode(errors="replace"))
+                else:
+                    self.fail("setup did not complete: " + output.decode(errors="replace"))
+            self.assertFalse(pending, output.decode(errors="replace"))
+            return output
+        finally:
+            os.close(fd)
+            if pid:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+
+    def test_disabled_choice_is_saved_without_requesting_another_key(self):
+        with tempfile.TemporaryDirectory() as directory:
+            home = pathlib.Path(directory)
+            output = self.interact(home, [(b"Esc leave", b"\x1b[A\r")])
+            self.assertIn("enabled = false", (home / ".cerul/config.toml").read_text())
+            self.assertNotIn(b"API key (hidden", output)
+            self.assertFalse((home / ".cerul/credentials.json").exists())
+
+    def test_custom_endpoint_saves_private_key_and_checks_transcription_protocol(self):
+        requests = []
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):
+                body = self.rfile.read(int(self.headers["Content-Length"]))
+                requests.append((self.path, body, self.headers.get("Authorization")))
+                response = json.dumps({"segments": [], "language": "en"}).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(response)))
+                self.end_headers()
+                self.wfile.write(response)
+
+            def log_message(self, *_):
+                pass
+
+        with http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            try:
+                with tempfile.TemporaryDirectory() as directory:
+                    home = pathlib.Path(directory)
+                    base = f"http://127.0.0.1:{server.server_port}/v1"
+                    output = self.interact(home, [
+                        (b"Esc leave", b"\x1b[B\x1b[B\x1b[B\r"),
+                        (b"Base URL", (base + "\n").encode()),
+                        (b"ASR model", b"fixture-whisper\n"),
+                        (b"API key (hidden", b"fixture-asr-key\n"),
+                    ], parent_ready=thread.start)
+                    config = (home / ".cerul/config.toml").read_text()
+                    self.assertIn(base, config)
+                    self.assertIn("enabled = true", config)
+                    self.assertNotIn("fixture-asr-key", config)
+                    self.assertNotIn(b"fixture-asr-key", output)
+                    keys = home / ".cerul/credentials.json"
+                    self.assertEqual(keys.stat().st_mode & 0o777, 0o600)
+                    self.assertIn("fixture-asr-key", json.loads(keys.read_text()).values())
+                    self.assertEqual(len(requests), 2)
+                    for path, body, auth in requests:
+                        self.assertEqual(path, "/v1/audio/transcriptions")
+                        self.assertEqual(auth, "Bearer fixture-asr-key")
+                        self.assertIn(b"verbose_json", body)
+                        self.assertIn(b"timestamp_granularities[]", body)
+            finally:
+                server.shutdown()
+                thread.join()


### PR DESCRIPTION
## Problem and behavior

Audio indexing previously relied on prompted Flash JSON and could fail the entire video with an opaque structured-output error. The CLI now fixes multimodal embedding to Gemini Embedding 2 (1536 dimensions) and treats speech transcription as an optional, separately configured capability.

- Add `cerul config` with Gemini, Groq, OpenAI, custom OpenAI-compatible ASR, and Disabled choices. Prompt when relevant settings or credentials are missing and speech work is pending, rather than on first launch. Persist defaults separately from private, endpoint-scoped credentials; environment keys take precedence. Machine invocations skip unconfigured speech without prompting.
- Use native Gemini 3.5 Transcribe word timestamps for the Gemini ASR preset. Normalize words into timed phrases, including zero-duration punctuation, and accept completed empty silence responses. Keep the existing prompted Gemini compatibility path and shared OpenAI/Groq multipart transcription protocol.
- Preserve searchable video/OCR embeddings when ASR fails, expose speech status and retained diagnostics, and resume missing work on a repeated index command. No automatic cross-provider fallback.
- Preserve detailed, sanitized provider rejection and window diagnostics from the earlier commits in this PR. Update configuration documentation, generated schemas, and the installed CLI skill.

- Follow-up fixes normalize the `models/` prefix for native ASR selection, load saved credentials for authenticated loopback endpoints, and use provider-neutral media notices. Failed recomputations retain a separate resumable checkpoint generation until successful publication, so an ordinary retry cannot silently accept the old transcript.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings` passed.
- `cargo test --locked`: 88 library, 19 binary, and 21 integration tests passed; focused failed-recomputation recovery regression passed on the final checkpoint path.
- Two actual PTY setup tests passed: persisted opt-out, and custom endpoint/model/hidden-key configuration against a local transcription server.
- Generated-schema check, documentation checks and 6 Python documentation tests, and source-package inventory checks passed.
- Fresh live default embedding, vision, and native transcription capability checks passed.
- Live Gemini test on a local 60-second video excerpt completed transcription and 9 index rows; a subsequent restricted-network run completed with zero model-request events. The earlier ASR failure path also published usable video/OCR vectors.
- OpenAI/Groq protocol behavior is covered by local mock endpoints, not live accounts. Private keys, media, and diagnostic artifacts are not included.

This PR prepares Cerul 0.0.9. PR CI and review are intentionally not awaited for the owner-authorized merge; release artifacts are built and published by the existing tag-triggered Release workflow.
