### PR TITLE
Release Cerul 0.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cerul"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerul"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 description = "Searchable video and annotation data, using your own model endpoints"

--- a/packaging/dist.toml
+++ b/packaging/dist.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerul"
-version = "0.0.9"
+version = "0.0.10"
 description = "Searchable video and annotation data, using your own model endpoints"
 license = "Apache-2.0 AND GPL-2.0-or-later AND Zlib"
 homepage = "https://cerul.ai"

--- a/skills/cerul/SKILL.md
+++ b/skills/cerul/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cerul
 description: Search local videos by meaning, exact words, or a reference image, and annotate actions, events, interactions, and states in videos or LeRobot demonstrations. Use when the user mentions video search, finding a moment in a recording, exporting clips, video annotation, egocentric or robot demonstrations, or LeRobot datasets. Requires the cerul command-line tool.
-generated-by: cerul 0.0.9
+generated-by: cerul 0.0.10
 generated-sha256: a6ff32afc3689dba25208ea9b7d9d547ca84984379aa34a426cc8825c5af3c2b
 ---
 


### PR DESCRIPTION
Prepare Cerul 0.0.10 with the indexing UX, default video understanding, hybrid retrieval, and review fixes merged in #263. Synchronize the Rust package, lockfile, distribution manifest, and generated agent skill version.

Validation: all 171 Rust tests, strict Clippy, formatting and documentation checks pass. Synthetic live checks confirm default Gemini embedding, vision and speech endpoints respond. The preceding implementation commit passed macOS arm64 and Linux x86_64 Core CI and native package builds. Public installer and published-binary acceptance will run after the version tag is released.
